### PR TITLE
Add as_array to spot crop generator

### DIFF
--- a/squidpy/im/object.py
+++ b/squidpy/im/object.py
@@ -467,7 +467,9 @@ class ImageContainer(FeatureMixin):
                 crop = crop.data.to_array().values
                 if crop.shape[0] == 1:
                     crop = crop.squeeze(0)
-            yield crop, obs_id  # type: ignore[misc]
+                yield crop
+            else:
+                yield crop, obs_id  # type: ignore[misc]
 
     @classmethod
     @d.get_sections(base="uncrop_img", sections=["Parameters", "Returns"])


### PR DESCRIPTION
@giovp 

This is a very quick impl., mostly for you to use in the tutorials. W.r.t. the the API, nothing will change (I hope), i.e. it will be an iterator of `numpy.arrays` with 1-Dim squeezed if it is one (i.e. [1, 256, 256, 3] -> [256, 256, 3], but [1, 256, 256, 1] -> [256, 256, 1]).
Is that ok? Also, are the obs_ids not important? I was thinking, since where the crop is pushed into the `metadata` of the `DataArray`, `obs_id` should be also pushed there - the API would be more uniform (iterator of arrays/ImageContainers, not of arrays/(IC, obs_id).
Maybe the best alternative is to have `return_ids: bool = False` and it if `return_ids=True`, it would then return:
- `(arr, id)` if `as_array = True`
- `(img_cont, id)` otherwise

Definitely more checks/tests should be done in #239

closes #240 

