### PR TITLE
fix the bug of relative coordinates

### DIFF
--- a/squidpy/im/_feature_mixin.py
+++ b/squidpy/im/_feature_mixin.py
@@ -343,12 +343,12 @@ class FeatureMixin:
             y_slc, x_slc = coord.to_image_coordinates(padding).slice
 
             # relative coordinates
-            y = (y - np.min(y)) / (np.max(y) - np.min(y))
-            x = (x - np.min(x)) / (np.max(x) - np.min(x))
+            #y = (y - np.min(y)) / (np.max(y) - np.min(y))
+            #x = (x - np.min(x)) / (np.max(x) - np.min(x))
 
             # coordinates in the uncropped image
-            y = coord.slice[0].start + (y_slc.stop - y_slc.start) * y
-            x = coord.slice[1].start + (x_slc.stop - x_slc.start) * x
+            y = coord.slice[0].start + y#(y_slc.stop - y_slc.start) * y
+            x = coord.slice[1].start + x#(x_slc.stop - x_slc.start) * x
 
             return np.c_[x, y]  # type: ignore[no-any-return]
 


### PR DESCRIPTION
## Description

I have changed the relative coordinate to exact coordinate in the `feature_segmentation` function.
There are two reasons:
1. because of the normalization of "np.max(y) - np.min(y)" in denominator, current relative coordinate will return nan if there is only one cell in spot.
2. exact coordinate looks more reasonable than the relative coordinate when visualizing the segmentation result with spatial image as background.

## How has this been tested?

I have tested the revised code in two Visium data, it works very well.