### PR TITLE
remove column assignment to improve compatibility with new cell metad…

### DIFF
--- a/squidpy/read/_read.py
+++ b/squidpy/read/_read.py
@@ -159,7 +159,6 @@ def vizgen(
 
     # fmt: off
     coords = pd.read_csv(path / meta_file, header=0, index_col=0)
-    coords.columns = ["fov", "volume", "center_x", "center_y", "min_x", "max_x", "min_y", "max_y"]
     # fmt: on
 
     adata.obs = pd.merge(adata.obs, coords, how="left", left_index=True, right_index=True)


### PR DESCRIPTION
## Description

This pull request addresses this issue https://github.com/scverse/squidpy/issues/647 where the read function is unable to support updated versions of cell metadata (see https://vizgen.github.io/vizgen-postprocessing/output_data_formats/entity_metadata_format.html). We remove the assignment of column names to allow for modifications to cell metadata. 

## How has this been tested?

I have tested that this modification allows squidpy to load the previous and current versions of cell metadata. 

```
adata = sq.read.vizgen(
...   'Mouse_Brain_Showcase/', 
...   counts_file = 'cell_by_gene.csv', 
...   meta_file = 'cell_metadata.csv')
```

## Closes
closes #647 
