### PR TITLE
Set index's dtype ib `sq.read.vizgen`/`sq.read.visium`

### DIFF
--- a/squidpy/read/_read.py
+++ b/squidpy/read/_read.py
@@ -157,9 +157,9 @@ def vizgen(
 
     adata.X = csr_matrix(adata.X)
 
-    # fmt: off
     coords = pd.read_csv(path / meta_file, header=0, index_col=0)
-    # fmt: on
+    # https://github.com/scverse/squidpy/issues/657
+    coords.set_index(coords.index.astype(adata.obs.index.dtype), inplace=True)
 
     adata.obs = pd.merge(adata.obs, coords, how="left", left_index=True, right_index=True)
     adata.obsm[Key.obsm.spatial] = adata.obs[["center_x", "center_y"]].values

--- a/squidpy/read/_read.py
+++ b/squidpy/read/_read.py
@@ -88,6 +88,8 @@ def visium(
         index_col=0,
     )
     coords.columns = ["in_tissue", "array_row", "array_col", "pxl_col_in_fullres", "pxl_row_in_fullres"]
+    # https://github.com/scverse/squidpy/issues/657
+    coords.set_index(coords.index.astype(adata.obs.index.dtype), inplace=True)
 
     adata.obs = pd.merge(adata.obs, coords, how="left", left_index=True, right_index=True)
     adata.obsm[Key.obsm.spatial] = adata.obs[["pxl_row_in_fullres", "pxl_col_in_fullres"]].values


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description

<!-- Clearly and concisely describe your changes. This section will be shown in the docs. -->
Set coordinates' index type to same as in :attr:`anndata.AnnData.obs` in :func:`squidpy.read.vizgen` and :func:`squidpy.read.visium`.

## How has this been tested?

<!-- Describe in detail how you've tested your changes. -->
No new tests.

## Closes

<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
closes #657 
