### PR TITLE
Convert cell_metadata index from integer to string for latest MERFISH public data

### DIFF
--- a/squidpy/read/_read.py
+++ b/squidpy/read/_read.py
@@ -89,7 +89,7 @@ def visium(
     )
     coords.columns = ["in_tissue", "array_row", "array_col", "pxl_col_in_fullres", "pxl_row_in_fullres"]
     # https://github.com/scverse/squidpy/issues/657
-    coords.set_index(coords.index.astype(adata.obs.index.dtype), inplace=True)
+    coords.set_index(coords.index.astype('str'), inplace=True)
 
     adata.obs = pd.merge(adata.obs, coords, how="left", left_index=True, right_index=True)
     adata.obsm[Key.obsm.spatial] = adata.obs[["pxl_row_in_fullres", "pxl_col_in_fullres"]].values

--- a/squidpy/read/_read.py
+++ b/squidpy/read/_read.py
@@ -89,7 +89,7 @@ def visium(
     )
     coords.columns = ["in_tissue", "array_row", "array_col", "pxl_col_in_fullres", "pxl_row_in_fullres"]
     # https://github.com/scverse/squidpy/issues/657
-    coords.set_index(coords.index.astype('str'), inplace=True)
+    coords.set_index(coords.index.astype("str"), inplace=True)
 
     adata.obs = pd.merge(adata.obs, coords, how="left", left_index=True, right_index=True)
     adata.obsm[Key.obsm.spatial] = adata.obs[["pxl_row_in_fullres", "pxl_col_in_fullres"]].values


### PR DESCRIPTION
## Description

In the latest MERFISH public data, the cell_metadata index is recognized as an integer, which requires conversion to a string format.  This commit adds a function to convert the index to a string, ensuring compatibility with downstream applications.

## How has this been tested?

When attempting to load the latest public data from https://vizgen.com/data-release-program/, specifically the FFPE_Human_Immuno_oncology dataset, I have encountered an issue where the 'obs' of the Anndata object is filled with NaN values. This issue is caused by the presence of different index types between 'adata.obs' and 'coords', which leads to errors when merging them.

I have found that this issue can be resolved by setting the data type of 'coords' as 'str'. After making this adjustment, the 'obs' of the Anndata object is populated with the expected data.