### PR TITLE
Converting cell_metadata from integer to string for latest MERFISH public data

### DIFF
--- a/squidpy/read/_read.py
+++ b/squidpy/read/_read.py
@@ -89,7 +89,7 @@ def visium(
     )
     coords.columns = ["in_tissue", "array_row", "array_col", "pxl_col_in_fullres", "pxl_row_in_fullres"]
     # https://github.com/scverse/squidpy/issues/657
-    coords.set_index(coords.index.astype("str"), inplace=True)
+    coords.set_index(coords.index.astype(adata.obs.index.dtype), inplace=True)
 
     adata.obs = pd.merge(adata.obs, coords, how="left", left_index=True, right_index=True)
     adata.obsm[Key.obsm.spatial] = adata.obs[["pxl_row_in_fullres", "pxl_col_in_fullres"]].values

--- a/squidpy/read/_read.py
+++ b/squidpy/read/_read.py
@@ -161,7 +161,7 @@ def vizgen(
 
     coords = pd.read_csv(path / meta_file, header=0, index_col=0)
     # https://github.com/scverse/squidpy/issues/657
-    coords.set_index(coords.index.astype(adata.obs.index.dtype), inplace=True)
+    coords.set_index(coords.index.astype("str"), inplace=True)
 
     adata.obs = pd.merge(adata.obs, coords, how="left", left_index=True, right_index=True)
     adata.obsm[Key.obsm.spatial] = adata.obs[["center_x", "center_y"]].values


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description

A previous pull request #679 by @djlee1 addressed this issue but implemented the code in the read_visium() function rather than in read_vizgen(). 

Here I made the changes to read_vizgen(). Looking through current issues on squidpy I didn't see any with the read_visium() function that would be addressed by the change, so I reverted to the previous version of the read_visium() code.

## How has this been tested?

I've tested this locally on the public MERSCOPE data mentioned in #686, and the AnnData observations data frame was correctly populated with values rather than NaNs.

I also confirmed that the changes didn't effect previous squidpy tutorials using Vizgen data ([mouse brain](https://squidpy.readthedocs.io/en/stable/external_tutorials/tutorial_vizgen.html#), [mouse liver](https://squidpy.readthedocs.io/en/stable/external_tutorials/tutorial_vizgen_mouse_liver.html)). 

<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
