### PR TITLE
change transformation_matrix column type to str

### DIFF
--- a/src/squidpy/read/_read.py
+++ b/src/squidpy/read/_read.py
@@ -169,6 +169,8 @@ def vizgen(
 
     if transformation_file is not None:
         matrix = pd.read_csv(path / f"images/{transformation_file}", sep=" ", header=None)
+        # https://github.com/scverse/squidpy/issues/727
+        matrix.columns = matrix.columns.astype(str)
         adata.uns[Key.uns.spatial][library_id]["scalefactors"] = {"transformation_matrix": matrix}
 
     return adata


### PR DESCRIPTION
## Description

Changed the column heading of the `transformation_matrix` in the `uns` slot from `int64` to `str` when `transformation_file` is read in. This is so resulting `adata` can be written out as h5ad file.

## How has this been tested?

Download public vizgen data then run the following:

```
from pathlib import Path
import scanpy as sc
import squidpy as sq

vizgen_dir = Path().resolve() / "HumanBreastCancerPatient1"

adata_bk = sq.read.vizgen(
    path=vizgen_dir,
    counts_file="cell_by_gene.csv",
    meta_file="cell_metadata.csv",
    transformation_file="micron_to_mosaic_pixel_transform.csv",
)

adata_bk.write("test.h5ad")
```

## Closes

`closes #727 `

