### PR TITLE
Fix var_by_distance to pass test after pandas update

### DIFF
--- a/src/squidpy/tl/_var_by_distance.py
+++ b/src/squidpy/tl/_var_by_distance.py
@@ -164,6 +164,9 @@ def var_by_distance(
         if isinstance(covariates, str):
             covariates = [covariates]
         df[covariates] = adata.obs[covariates].copy()
+    # match index with .obs
+    if isinstance(groups, list):
+        df = df.reindex(adata.obs.index)
     if copy:
         logg.info("Finish", time=start)
         return df


### PR DESCRIPTION
## Description

Test for tl._var_by_dist.py fails if more than one anchor point is used, since the indices of the df no longer match those of .obs

## How has this been tested?

By comparing assertion result of previous code with result after reindexing