### PR TITLE
fixed reading 10x formatted visium mtx files

### DIFF
--- a/src/squidpy/read/_utils.py
+++ b/src/squidpy/read/_utils.py
@@ -4,10 +4,10 @@ from pathlib import Path
 from typing import Any, Optional, Tuple
 
 import numpy as np
-from anndata import AnnData, read_mtx, read_text
+from anndata import AnnData, read_text
 from h5py import File
 from PIL import Image
-from scanpy import read_10x_h5
+from scanpy import read_10x_h5, read_10x_mtx
 
 from squidpy._constants._pkg_constants import Key
 from squidpy._utils import NDArrayA
@@ -49,7 +49,7 @@ def _read_counts(
     if count_file.endswith((".csv", ".txt")):
         adata = read_text(path / count_file, **kwargs)
     elif count_file.endswith(".mtx"):
-        adata = read_mtx(path / count_file, **kwargs)
+        adata = read_10x_mtx(path, **kwargs) 
     else:
         raise NotImplementedError("TODO")
 


### PR DESCRIPTION
solves #802

**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description

Replaced Anndata's read_mtx function with scanpys native read_10x_mtx function for reading mtx formatted visium experiments. This solves issues with matching the spot positions to barcodes.

## How has this been tested?

all tests ran locally 

## Closes

closes #802 
