### PR TITLE
Add method to calculate embeddings for variable by distance aggregation

### DIFF
--- a/src/squidpy/tl/__init__.py
+++ b/src/squidpy/tl/__init__.py
@@ -3,3 +3,4 @@
 from __future__ import annotations
 
 from squidpy.tl._var_by_distance import var_by_distance
+from squidpy.tl._var_embeddings import var_embeddings

--- a/src/squidpy/tl/_var_embeddings.py
+++ b/src/squidpy/tl/_var_embeddings.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+
+import pandas as pd
+from anndata import AnnData
+from scanpy import logging as logg
+from sklearn.preprocessing import StandardScaler
+import umap
+
+from squidpy._docs import d
+
+__all__ = ["var_embeddings"]
+
+
+@d.dedent
+def var_embeddings(
+    adata: AnnData,
+    cluster_key: str,
+    design_matrix_key: str = "design_matrix",
+    n_bins: int = 100,
+    include_anchor: bool = False,
+) -> AnnData:
+    """
+    Cluster variables by previously calculated distance to an anchor point.
+
+    Parameters
+    ----------
+    %(adata)s
+    cluster_key
+        Annotation column in `.obs` that is used as anchor.
+    design_matrix_key
+        Name of the design matrix saved to `.obsm`.
+    n_bins
+        Number of bins to use for aggregation.
+    include_anchor
+        Whether to include the variable counts belonging to the anchor point in the aggregation.
+    Returns
+    -------
+    If ``copy = True``, returns the design_matrix with the distances to an anchor point
+    Otherwise, stores design_matrix in `.obsm`.
+    """
+    if design_matrix_key not in adata.obsm.keys():
+        raise ValueError(f"`.obsm['{design_matrix_key}']` does not exist. Aborting.")
+
+    logg.info("Calculating embeddings for distance aggregations by gene.")
+
+    df = adata.obsm[design_matrix_key].copy()
+
+    # bin the data by distance
+    df["bins"] = pd.cut(df[cluster_key], bins=n_bins)
+
+    # get median value of each interval
+    df['median_value'] = df['bins'].apply(calculate_median)
+
+    # turn categorical NaNs into float 0s
+    df['median_value'] = pd.to_numeric(df['median_value'], errors='coerce').fillna(0).astype(float)
+
+    # get count matrix and add binned distance to each .obs
+    X_df = adata.to_df()
+    X_df["distance"] = df["median_value"].copy()
+
+    # transpose the count matrix
+    X_df_T = X_df.T
+
+    # aggregate the transposed count matrix by the distances and remove the distance row
+    mth_row_values = X_df_T.iloc[-1]
+    result = X_df_T.groupby(mth_row_values, axis=1).sum()
+    result.drop(result.tail(1).index,inplace=True)
+
+    # optionally include or remove variable values for distance 0 (anchro point)
+    if not include_anchor:
+        result = result.drop(result.columns[0], axis=1)
+
+    reducer = umap.UMAP()
+    
+    # scale the data and reduce dimensionality
+    scaled_exp = StandardScaler().fit_transform(result.values)
+    scaled_exp_df = pd.DataFrame(scaled_exp, index=result.index, columns=result.columns)
+    embedding = reducer.fit_transform(scaled_exp_df)
+
+    adata.varm[f"{n_bins}_bins_distance_aggregation"] = result
+    embedding_df = pd.DataFrame(embedding, index=result.index)
+    embedding_df["var"] = result.index
+    adata.uns[f"{n_bins}_bins_distance_embeddings"] = embedding_df
+
+    return
+
+def calculate_median(interval):
+    median = interval.mid
+
+    return median
+


### PR DESCRIPTION
## Description

Adds a method in ```tools``` to calculate embeddings of variables by their counts aggregated by distance.

## Example usage

`import squidpy as sq`

load example data set
`adata = sq.datasets.seqfish()`

Calculate distances of each observation to a specified anchor point (e.g. cell type or tissue location). Here we use cell type "Endothelium" in the annotation column "celltype_mapped_refined":
`sq.tl.var_by_distance(adata, groups="Endothelium", cluster_key="celltype_mapped_refined")`

The resulting distances are stored in `adata.obsm["design_matrix"]`. Now we can calculate the embeddings:
`sq.tl.var_embeddings(adata, cluster_key="Endothelium", design_matrix_key="design_matrix")`

Note that by default the bin of distance 0, meaning the counts that belong to the anchor point, are excluded. This can be changed by setting `include_anchor=False` in `sq.tl.var_embeddings()`.

By default 100 bins are used. The resulting embeddings are stored in `adata.uns["100_bins_distance_embeddings"]`.
We can plot the embedding (umap) as follows:

`embedding = adata.uns["100_bins_distance_embeddings"]`
`plt.scatter(embedding[0], embedding[1], c="grey")`
`plt.gca().set_aspect('equal', 'datalim')`
`plt.title('UMAP', fontsize=20)`

which results in:
![image](https://github.com/scverse/squidpy/assets/64135338/b0d4be6c-5640-4344-8c18-7d298610939f)

## TODO

- [ ] Add a plotting function so this doesn't need to be done manually.
- [ ] Cluster the data
