### PR TITLE
Update spatialdata dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,9 @@ dependencies = [
    "tifffile!=2022.4.22",
    "tqdm>=4.50.2",
    "validators>=0.18.2",
-   "xarray>=0.16.1",
+   "xarray>=0.16.1,<2024.10.0",
    "zarr>=2.6.1",
-   "spatialdata>=0.2.0",
+   "spatialdata>=0.2.5",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description

The latest version of xarray directly includes `DataTree` but with a datamodel that is different from before. Since the xarray version was not constraint in `SpatialData` this led to errors. The current latest version of `SpatialData` constraints the xarray version used until the latest version of xarray is supported.

## How has this been tested?

local tests
