### PR TITLE
Remove Gio from being autoassigned to questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -3,7 +3,7 @@ name: Question
 about: Ask a question about Squidpy
 title:
 labels: question
-assignees: "giovp"
+assignees:
 ---
 
 <!-- Put your question regarding Squidpy below: -->


### PR DESCRIPTION
You've already removed Mike but forgot about this one @timtreis 

See internal Slack discussion