### PR TITLE
(fix): upper bound `zarr`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
    "tqdm>=4.50.2",
    "validators>=0.18.2",
    "xarray>=0.16.1,<2024.10.0",
-   "zarr>=2.6.1",
+   "zarr>=2.6.1,<3.0.0",
    "spatialdata>=0.2.5",
 ]
 


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description

See #933: `zarr` needs to be upper bounded as other dependencies cannot use `zarr` `v3` yet see e.g., https://github.com/scverse/anndata/issues/1817

## How has this been tested?

N/A

## Closes
Fixes  #933
<!-- If applicable, type `closes #XXXX` in your comment to auto-close the issue that this PR fixes. -->
