### PR TITLE
Added function to download Visium as SpatialData

### DIFF
--- a/.scripts/ci/download_data.py
+++ b/.scripts/ci/download_data.py
@@ -54,7 +54,7 @@ def main(args: argparse.Namespace) -> None:
             path = _ROOT / f"{func_name}.{ext}"
 
             _print_message(func_name, path)
-            obj = visium_hne_sdata(path)
+            obj = visium_hne_sdata(_ROOT)
 
             assert path.is_dir(), f"Expected a .zarr folder at {path}"
             continue

--- a/.scripts/ci/download_data.py
+++ b/.scripts/ci/download_data.py
@@ -5,6 +5,8 @@ import argparse
 from pathlib import Path
 from typing import Any
 
+from squidpy.datasets import visium_hne_sdata
+
 _CNT = 0  # increment this when you want to rebuild the CI cache
 _ROOT = Path.home() / ".cache" / "squidpy"
 
@@ -39,14 +41,25 @@ def main(args: argparse.Namespace) -> None:
 
     if args.dry_run:
         for func_name, ext in zip(all_datasets, all_extensions):
+            if func_name == "visium_hne_sdata":
+                ext = "zarr"
             path = _ROOT / f"{func_name}.{ext}"
             _print_message(func_name, path, dry_run=True)
         return
 
     # could be parallelized, but on CI it largely does not matter (usually limited to 2 cores + bandwidth limit)
     for func_name, ext in zip(all_datasets, all_extensions):
-        path = _ROOT / f"{func_name}.{ext}"
+        if func_name == "visium_hne_sdata":
+            ext = "zarr"
+            path = _ROOT / f"{func_name}.{ext}"
 
+            _print_message(func_name, path)
+            obj = visium_hne_sdata(path)
+
+            assert path.is_dir(), f"Expected a .zarr folder at {path}"
+            continue
+
+        path = _ROOT / f"{func_name}.{ext}"
         _print_message(func_name, path)
         obj = _maybe_download_data(func_name, path)
 

--- a/src/squidpy/datasets/_10x_datasets.py
+++ b/src/squidpy/datasets/_10x_datasets.py
@@ -168,6 +168,9 @@ def visium_hne_sdata(filename: Path | str | None = None) -> SpatialData:
     SpatialData
         The downloaded and extracted Visium H&E dataset as a `SpatialData` object.
     """
+
+    FIGSHARE_ID = "52370645"
+
     if filename is None:
         filename = Path.home() / ".cache/squidpy/visium_hne_sdata.zip"
     else:
@@ -191,7 +194,7 @@ def visium_hne_sdata(filename: Path | str | None = None) -> SpatialData:
             logg.info(f"Downloading Visium H&E SpatialData to {filename}")
             check_presence_download(
                 filename=filename,
-                backup_url="https://ndownloader.figshare.com/files/52048571",
+                backup_url=f"https://ndownloader.figshare.com/files/{FIGSHARE_ID}",
             )
             logg.info(f"Extracting dataset from {filename} to {extracted_path}")
             shutil.unpack_archive(str(filename), str(extracted_path))

--- a/src/squidpy/datasets/_10x_datasets.py
+++ b/src/squidpy/datasets/_10x_datasets.py
@@ -19,7 +19,7 @@ from scanpy._utils import check_presence_download
 from spatialdata import SpatialData
 
 from squidpy._constants._constants import TenxVersions
-from squidpy.datasets._utils import PathLike
+from squidpy.datasets._utils import DEFAULT_CACHE_DIR, PathLike, _get_zipped_dataset
 
 __all__ = ["visium"]
 
@@ -144,7 +144,7 @@ def visium(
     return read_visium(base_dir / sample_id)
 
 
-def visium_hne_sdata(folderpath: Path | str) -> sd.SpatialData:
+def visium_hne_sdata(folderpath: Path | str | None = None) -> sd.SpatialData:
     """
     Downloads a Visium H&E dataset into a specified folder and returns it as a `SpatialData` object.
 
@@ -165,31 +165,15 @@ def visium_hne_sdata(folderpath: Path | str) -> sd.SpatialData:
     """
 
     FIGSHARE_ID = "52370645"
+    DATASET_NAME = "visium_hne_sdata"
 
-    folderpath = Path(folderpath).expanduser().absolute()
-    if not folderpath.is_dir():
-        raise ValueError(f"Expected a directory path for `folderpath`, found: {folderpath}")
+    if folderpath is None:
+        folderpath = DEFAULT_CACHE_DIR
+    else:
+        folderpath = Path(folderpath).expanduser().absolute()
 
-    download_zip = folderpath / "visium_hne_sdata.zip"
-    extracted_path = folderpath / "visium_hne_sdata.zarr"
-
-    if not download_zip.exists():
-        try:
-            logg.info(f"Downloading Visium H&E SpatialData to {download_zip}")
-            check_presence_download(
-                filename=download_zip,
-                backup_url=f"https://ndownloader.figshare.com/files/{FIGSHARE_ID}",
-            )
-            logg.info(f"Extracting dataset from {download_zip} to {extracted_path}")
-        except Exception as e:
-            logg.error(f"Failed to download or extract dataset: {e}")
-            raise
-
-    if not extracted_path.exists():
-        try:
-            shutil.unpack_archive(str(download_zip), folderpath)
-        except Exception as e:
-            logg.error(f"Failed to extract dataset: {e}")
-            raise
-
-    return sd.read_zarr(extracted_path)
+    return _get_zipped_dataset(
+        folderpath=folderpath,
+        dataset_name=DATASET_NAME,
+        figshare_id=FIGSHARE_ID,
+    )

--- a/src/squidpy/datasets/_10x_datasets.py
+++ b/src/squidpy/datasets/_10x_datasets.py
@@ -202,4 +202,5 @@ def visium_hne_sdata(filename: Path | str | None = None) -> SpatialData:
             logg.error(f"Failed to download or extract dataset: {e}")
             raise
 
+    print(filename, extracted_path)
     return sd.read_zarr(extracted_path)

--- a/src/squidpy/datasets/__init__.py
+++ b/src/squidpy/datasets/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from squidpy.datasets._10x_datasets import visium
+from squidpy.datasets._10x_datasets import visium, visium_hne_sdata
 from squidpy.datasets._dataset import *  # noqa: F403
 from squidpy.datasets._image import *  # noqa: F403

--- a/src/squidpy/datasets/_dataset.py
+++ b/src/squidpy/datasets/_dataset.py
@@ -90,6 +90,7 @@ __all__ = [  # noqa: F822
     "seqfish",
     "visium_hne_adata",
     "visium_hne_adata_crop",
+    "visium_hne_sdata",
     "visium_fluo_adata",
     "visium_fluo_adata_crop",
     "sc_mouse_cortex",

--- a/src/squidpy/datasets/_dataset.py
+++ b/src/squidpy/datasets/_dataset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import copy
 
+from squidpy.datasets._10x_datasets import visium_hne_sdata
 from squidpy.datasets._utils import AMetadata
 
 _4i = AMetadata(

--- a/src/squidpy/datasets/_utils.py
+++ b/src/squidpy/datasets/_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -9,6 +10,7 @@ from pathlib import Path
 from typing import Any, TypeAlias, Union
 
 import anndata
+import spatialdata as sd
 from anndata import AnnData
 from scanpy import logging as logg
 from scanpy import read
@@ -16,6 +18,7 @@ from scanpy._utils import check_presence_download
 
 PathLike: TypeAlias = os.PathLike[str] | str
 Function_t: TypeAlias = Callable[..., AnnData | Any]
+DEFAULT_CACHE_DIR = Path.home() / ".cache" / "squidpy"
 
 
 @dataclass(frozen=True)
@@ -177,3 +180,42 @@ class ImgMetadata(Metadata):
     @property
     def _extension(self) -> str:
         return ".tiff"
+
+
+def _get_zipped_dataset(folderpath: Path, dataset_name: str, figshare_id: str) -> sd.SpatialData:
+    """Returns a specific dataset as SpatialData object. If the file is not present on disk, it will be downloaded and extracted."""
+
+    if not folderpath.is_dir():
+        raise ValueError(f"Expected a directory path for `folderpath`, found: {folderpath}")
+
+    download_zip = folderpath / f"{dataset_name}.zip"
+    extracted_path = folderpath / f"{dataset_name}.zarr"
+
+    # Return early if data is already extracted
+    if extracted_path.exists():
+        logg.info(f"Loading existing dataset from {extracted_path}")
+        return sd.read_zarr(extracted_path)
+
+    # Download if necessary
+    if not download_zip.exists():
+        logg.info(f"Downloading Visium H&E SpatialData to {download_zip}")
+        try:
+            check_presence_download(
+                filename=download_zip,
+                backup_url=f"https://ndownloader.figshare.com/files/{figshare_id}",
+            )
+        except Exception as e:
+            raise RuntimeError(f"Failed to download dataset: {e}") from e
+
+    # Extract if necessary
+    if not extracted_path.exists():
+        logg.info(f"Extracting dataset from {download_zip} to {extracted_path}")
+        try:
+            shutil.unpack_archive(str(download_zip), folderpath)
+        except Exception as e:
+            raise RuntimeError(f"Failed to extract dataset: {e}") from e
+
+    if not extracted_path.exists():
+        raise RuntimeError(f"Expected extracted data at {extracted_path}, but not found")
+
+    return sd.read_zarr(extracted_path)

--- a/tests/datasets/test_download_visium_dataset.py
+++ b/tests/datasets/test_download_visium_dataset.py
@@ -8,10 +8,10 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import spatialdata as sd
 from anndata.tests.helpers import assert_adata_equal
 from scanpy._settings import settings
 
-import spatialdata as sd
 from squidpy.datasets import visium, visium_hne_sdata
 
 
@@ -39,18 +39,14 @@ def test_visium_datasets(tmpdir, sample):
     # Test that downloading tissue image works
     sample_dataset = visium(sample, include_hires_tiff=True)
     expected_image_path = settings.datasetdir / sample / "image.tif"
-    image_path = Path(
-        sample_dataset.uns["spatial"][sample]["metadata"]["source_image_path"]
-    )
+    image_path = Path(sample_dataset.uns["spatial"][sample]["metadata"]["source_image_path"])
     assert image_path == expected_image_path
 
     # Test that tissue image exists and is a valid image file
     assert image_path.exists()
 
     # Test that tissue image is a tif image file (using `file`)
-    process = subprocess.run(
-        ["file", "--mime-type", image_path], stdout=subprocess.PIPE
-    )
+    process = subprocess.run(["file", "--mime-type", image_path], stdout=subprocess.PIPE)
     output = process.stdout.strip().decode()  # make process output string
     assert output == str(image_path) + ": image/tiff"
 

--- a/tests/datasets/test_download_visium_dataset.py
+++ b/tests/datasets/test_download_visium_dataset.py
@@ -11,13 +11,19 @@ import pytest
 from anndata.tests.helpers import assert_adata_equal
 from scanpy._settings import settings
 
-from squidpy.datasets import visium
+import spatialdata as sd
+from squidpy.datasets import visium, visium_hne_sdata
 
 
 @pytest.mark.timeout(120)
 @pytest.mark.internet()
 @pytest.mark.parametrize(
-    "sample", ["V1_Mouse_Kidney", "Targeted_Visium_Human_SpinalCord_Neuroscience", "Visium_FFPE_Human_Breast_Cancer"]
+    "sample",
+    [
+        "V1_Mouse_Kidney",
+        "Targeted_Visium_Human_SpinalCord_Neuroscience",
+        "Visium_FFPE_Human_Breast_Cancer",
+    ],
 )
 def test_visium_datasets(tmpdir, sample):
     # Tests that reading / downloading datasets works and it does not have any global effects
@@ -33,13 +39,26 @@ def test_visium_datasets(tmpdir, sample):
     # Test that downloading tissue image works
     sample_dataset = visium(sample, include_hires_tiff=True)
     expected_image_path = settings.datasetdir / sample / "image.tif"
-    image_path = Path(sample_dataset.uns["spatial"][sample]["metadata"]["source_image_path"])
+    image_path = Path(
+        sample_dataset.uns["spatial"][sample]["metadata"]["source_image_path"]
+    )
     assert image_path == expected_image_path
 
     # Test that tissue image exists and is a valid image file
     assert image_path.exists()
 
     # Test that tissue image is a tif image file (using `file`)
-    process = subprocess.run(["file", "--mime-type", image_path], stdout=subprocess.PIPE)
+    process = subprocess.run(
+        ["file", "--mime-type", image_path], stdout=subprocess.PIPE
+    )
     output = process.stdout.strip().decode()  # make process output string
     assert output == str(image_path) + ": image/tiff"
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.internet()
+def test_visium_sdata_dataset(tmpdir):
+    sdata = visium_hne_sdata(Path(tmpdir))
+    assert isinstance(sdata, sd.SpatialData)
+    assert list(sdata.shapes.keys()) == ["spots"]
+    assert list(sdata.images.keys()) == ["hne"]

--- a/tests/image/test_io.py
+++ b/tests/image/test_io.py
@@ -18,7 +18,7 @@ class TestIO:
         dtype = np.uint8 if len(shape) <= 3 else np.float32
         img = np.random.randint(0, 255, size=shape).astype(dtype)
         # set `photometric` to remove warnings
-        tifffile.imwrite(path, img, photometric=tifffile.TIFF.PHOTOMETRIC.MINISBLACK)
+        tifffile.imwrite(path, img, photometric="MINISBLACK")
 
         return img
 

--- a/tests/image/test_io.py
+++ b/tests/image/test_io.py
@@ -17,8 +17,15 @@ class TestIO:
     def _create_image(path: str, shape: tuple[int, ...]):
         dtype = np.uint8 if len(shape) <= 3 else np.float32
         img = np.random.randint(0, 255, size=shape).astype(dtype)
-        # set `photometric` to remove warnings
-        tifffile.imwrite(path, img, photometric="MINISBLACK")
+
+        try:
+            # Old usage (works up to tifffile<2025.2.18)
+            photometric = tifffile.TIFF.PHOTOMETRIC.MINISBLACK
+        except AttributeError:
+            # New usage (works on tifffile >=2025.2.18)
+            photometric = "MINISBLACK"
+
+        tifffile.imwrite(path, img, photometric=photometric)
 
         return img
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,9 +41,9 @@ sort = Miss
 
 [gh-actions]
 python =
-    3.10: py310
-    3.11: py311
-    3.12: py312
+    3.10: py3.10
+    3.11: py3.11
+    3.12: py3.12
 
 [gh-actions:env]
 PLATFORM =
@@ -55,7 +55,10 @@ isolated_build = True
 envlist =
     covclean
     lint
-    py{3.10,3.11}-{linux,macos}
+    py3.10-linux
+    py3.11-linux
+    py3.12-linux
+    py3.12-macos
     coverage
     readme
     check-docs
@@ -93,7 +96,7 @@ deps =
     coverage
     diff_cover
 skip_install = true
-depends = py{310,311,312}-{linux,macos}
+depends = py3.10-linux, py3.11-linux, py3.12-linux, py3.12-macos
 parallel_show_output = True
 commands =
     coverage report --omit="tox/*"


### PR DESCRIPTION
The `squidpy.datasets` function were downloading AnnDatas or ImageContainers. For a lot of work, I'd love to have an easy SpatialData download. So here it is. Data was created as described here: https://github.com/scverse/spatialdata-notebooks/pull/131

Edit: I had to write some quite hacky code around the download function to also have it be automatically downloaded during CI/CD. Theoretically, that entire part should be refactored because it's (unnecessarily complicated)**3, but time yada yada