### PR TITLE
Updated linkcheck times for sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,6 +144,10 @@ bibtex_bibfiles = ["references.bib"]
 bibtex_reference_style = "author_year"
 bibtex_default_style = "alpha"
 
+# sphinx linktime checkouts (esp bioRxiv is spotty)
+linkcheck_timeout = 90
+linkcheck_retries = 2
+
 # spelling
 spelling_lang = "en_US"
 spelling_warning = True


### PR DESCRIPTION
Every now and then CI/CD fails because sphinx can't reach links in time, f.e. [here](https://github.com/scverse/squidpy/actions/runs/13334734059/job/37247296268). Increased timelimit to hopefully avoid that.