### PR TITLE
Fixed error in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,9 +41,9 @@ sort = Miss
 
 [gh-actions]
 python =
-    3.10: py310
-    3.11: py311
-    3.12: py312
+    3.10: py3.10
+    3.11: py3.11
+    3.12: py3.12
 
 [gh-actions:env]
 PLATFORM =
@@ -55,7 +55,10 @@ isolated_build = True
 envlist =
     covclean
     lint
-    py{3.10,3.11}-{linux,macos}
+    py3.10-linux
+    py3.11-linux
+    py3.12-linux
+    py3.12-macos
     coverage
     readme
     check-docs
@@ -93,7 +96,7 @@ deps =
     coverage
     diff_cover
 skip_install = true
-depends = py{310,311,312}-{linux,macos}
+depends = py3.10-linux, py3.11-linux, py3.12-linux, py3.12-macos
 parallel_show_output = True
 commands =
     coverage report --omit="tox/*"


### PR DESCRIPTION
A mismatch between the environment names defined in [gh-actions] (e.g. py3.10) and those in [tox] envlist (e.g. py310) caused tests to fail because the correct tox environment could not be found. Renaming the envlist to match the factors (e.g. py3.10-linux → py310-linux or vice versa) fixed the issue.