### PR TITLE
Mirror `SpatialData` release action

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+changelog:
+    exclude:
+        labels:
+            - release-ignore
+        authors:
+            - pre-commit-ci
+    categories:
+        - title: Added
+          labels:
+              - "release-added"
+        - title: Changed
+          labels:
+              - "release-changed"
+        - title: Deprecated
+          labels:
+              - "release-deprecated"
+        - title: Removed
+          labels:
+              - "release-removed"
+        - title: Fixed
+          labels:
+              - "release-fixed"
+        - title: Security
+          labels:
+              - "release-security"
+        - title: Other Changes
+          labels:
+              - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,66 +1,31 @@
 name: Release
 
-on: create
+on:
+    release:
+        types: [published]
 
 jobs:
-    release:
-        if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
+    package_and_release:
         runs-on: ubuntu-latest
+        if: startsWith(github.ref, 'refs/tags/v')
         steps:
             - uses: actions/checkout@v3
-              with:
-                  token: ${{ secrets.TOWNCRIER_TOKEN }}
-                  fetch-depth: 0
-                  submodules: true
-
-            - name: Set up Python 3.10
+            - name: Set up Python 3.12
               uses: actions/setup-python@v4
               with:
-                  python-version: "3.10"
-
-            - name: Extract the tag
-              id: vars
-              run: |
-                  echo "::set-output name=tag::${GITHUB_REF##*/}"
-
-            - name: Check tag validity
-              env:
-                  VERSION: ${{ steps.vars.outputs.tag }}
-              run: |
-                  grep "^v[[:digit:]]\.[[:digit:]]\.[[:digit:]]$" <<< "$VERSION" || (echo "Invalid version: '$VERSION'" && exit 42)
-
-            - name: Install dependencies
-              run: |
-                  sudo apt install pandoc
-                  python -m pip install --upgrade pip
-                  pip install tox bump2version
-                  pip install -e '.'
-
-            - name: Check generated docs
-              run: |
-                  tox -e check-docs
-
-            - name: Bump the version
-              # the part (patch) doesn't matter when supplying --new-version
-              env:
-                  VERSION: ${{ steps.vars.outputs.tag }}
-              run: |
-                  bump2version patch --no-commit --no-tag --verbose --new-version "${VERSION/v/}"
-
-            - name: Commit version bump
-              uses: stefanzweifel/git-auto-commit-action@v4
+                  python-version: "3.12"
+                  cache: pip
+            - name: Install build dependencies
+              run: python -m pip install --upgrade pip wheel twine build
+            - name: Build package
+              run: python -m build
+            - name: Check package
+              run: twine check --strict dist/*.whl
+            - name: Install hatch
+              run: pip install hatch
+            - name: Build project for distribution
+              run: hatch build
+            - name: Publish a Python distribution to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
               with:
-                  file_pattern: .bumpversion.cfg
-                  commit_user_name: CI
-                  commit_message: ${{ format('[auto][ci skip] Release {0}', steps.vars.outputs.tag) }}
-                  tagging_message: ${{ steps.vars.outputs.tag }}
-                  skip_dirty_check: false
-
-            # `Test` triggers `Deployment`
-            # TODO(michalk8): can't find WD for `Test`
-            - name: Invoke deployment workflow
-              uses: benc-uk/workflow-dispatch@v1
-              with:
-                  workflow: Deployment
-                  token: ${{ secrets.RELEASE_DISPATCH_TOKEN }}
-                  inputs: '{ "reason": "release" }'
+                  password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
To simplify maintenance, we're now doing the same release process as SpatialData