### PR TITLE
Change niche flavor to cellcharter_simple and default distance = 3

### DIFF
--- a/src/squidpy/_constants/_constants.py
+++ b/src/squidpy/_constants/_constants.py
@@ -129,6 +129,6 @@ class TenxVersions(str, ModeEnum):
 class NicheDefinitions(ModeEnum):
     NEIGHBORHOOD = "neighborhood"
     UTAG = "utag"
-    CELLCHARTER = "cellcharter"
+    CELLCHARTER = "cellcharter_simple"
     SPOT = "spot"
     BANKSY = "banksy"


### PR DESCRIPTION
## Description
- Change `flavor` option in `calculate_niche to `cellcharter_simple` for CellCharter
- Default `distance = 3` for `cellcharter_simple`. 

## How has this been tested?
`pytest` runs successfully. 
However, I see there are no unit tests for `calculate_niche` with `cellcharter` (now `cellcharter_simple`).

## Closes
Closes #977 