### PR TITLE
Fix IO warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: false
 default_stages:
-    - commit
-    - push
+    - pre-commit
+    - pre-push
 minimum_pre_commit_version: 2.9.3
 repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -12,10 +12,6 @@ repos:
             args: [--fix, --exit-non-zero-on-fix]
           - id: ruff-format
             types_or: [python, pyi, jupyter]
-    - repo: https://github.com/asottile/blacken-docs
-      rev: 1.19.1
-      hooks:
-          - id: blacken-docs
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v1.15.0
       hooks:

--- a/src/squidpy/read/_utils.py
+++ b/src/squidpy/read/_utils.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from anndata import AnnData, read_text
+from anndata import AnnData
+from anndata.io import read_text
 from h5py import File
 from PIL import Image
 from scanpy import read_10x_h5, read_10x_mtx


### PR DESCRIPTION
Fixes

```
/home/lukas/miniforge3/envs/lamindb/lib/python3.12/site-packages/anndata/utils.py:429: FutureWarning: Importing read_text from `anndata` is deprecated. Import anndata.io.read_text instead.
  warnings.warn(msg, FutureWarning)
```
