### PR TITLE
Docs: Edit the argument documentation of `n_jobs` of the `parallelize` function

### DIFF
--- a/src/squidpy/_docs.py
+++ b/src/squidpy/_docs.py
@@ -107,7 +107,8 @@ Nothing, just plots the figure and optionally saves the plot.
 """
 _parallelize = """\
 n_jobs
-    Number of parallel jobs.
+    Number of parallel jobs to use. If the function uses numba compiled functions, numba may
+    use cores depending on the number of threads set in the environment regardless of this argument.
 backend
     Parallelization backend to use. See :class:`joblib.Parallel` for available options.
 show_progress_bar

--- a/src/squidpy/_utils.py
+++ b/src/squidpy/_utils.py
@@ -88,7 +88,9 @@ def parallelize(
     collection
         Sequence of items to split into chunks.
     n_jobs
-        Number of parallel jobs.
+        Number of parallel jobs to use. If the function uses numba compiled functions, numba may
+        may use cores depending on the number of threads set in the environment regardless of this argument.
+        This argument will be removed in the future.
     n_split
         Split ``collection`` into ``n_split`` chunks.
         If <= 0, ``collection`` is assumed to be already split into chunks.

--- a/src/squidpy/_utils.py
+++ b/src/squidpy/_utils.py
@@ -89,7 +89,7 @@ def parallelize(
         Sequence of items to split into chunks.
     n_jobs
         Number of parallel jobs to use. If the function uses numba compiled functions, numba may
-        may use cores depending on the number of threads set in the environment regardless of this argument.
+        use cores depending on the number of threads set in the environment regardless of this argument.
     n_split
         Split ``collection`` into ``n_split`` chunks.
         If <= 0, ``collection`` is assumed to be already split into chunks.

--- a/src/squidpy/_utils.py
+++ b/src/squidpy/_utils.py
@@ -90,7 +90,6 @@ def parallelize(
     n_jobs
         Number of parallel jobs to use. If the function uses numba compiled functions, numba may
         may use cores depending on the number of threads set in the environment regardless of this argument.
-        This argument will be removed in the future.
     n_split
         Split ``collection`` into ``n_split`` chunks.
         If <= 0, ``collection`` is assumed to be already split into chunks.


### PR DESCRIPTION
Related: https://github.com/scverse/squidpy/issues/957

## Description

Following the discussion in https://github.com/scverse/squidpy/pull/984#issuecomment-2783410367 I modified the docs. I also wrote that this argument will be removed in the future based on our conversations but I am not sure about that.

If that is correct I will create an issue titled: `Reconsidering usage of paralellize` or something like that

