### PR TITLE
Ligrec Reproducibility and Bug Fix in Sparse Data.

### DIFF
--- a/src/squidpy/gr/_ligrec.py
+++ b/src/squidpy/gr/_ligrec.py
@@ -731,12 +731,12 @@ def _analysis(
 
         return TempResult(means=means, pvalues=pvalues)
 
-    data = data.astype(np.float64, copy=False)
     groups = data.groupby("clusters", observed=True)
     clustering = np.array(data["clusters"].values, dtype=np.int32)
 
     mean = groups.mean().values.T  # (n_genes, n_clusters)
-    mask = groups.apply(lambda c: ((c > 0).sum() / len(c)) >= threshold).values.T  # (n_genes, n_clusters)
+    mask = groups.apply(lambda c: ((c > 0).astype(int).sum() / len(c)) >= threshold).values.T  # (n_genes, n_clusters)
+
     # (n_cells, n_genes)
     data = np.array(data[data.columns.difference(["clusters"])].values, dtype=np.float64, order="C")
     # all 3 should be C contiguous

--- a/src/squidpy/gr/_ligrec.py
+++ b/src/squidpy/gr/_ligrec.py
@@ -737,7 +737,9 @@ def _analysis(
     mean = groups.mean().values.T  # (n_genes, n_clusters)
     # see https://github.com/scverse/squidpy/pull/991#issuecomment-2888506296
     # for why we need to cast to int64 here
-    mask = groups.apply(lambda c: ((c > 0).astype(np.int64).sum() / len(c)) >= threshold).values.T  # (n_genes, n_clusters)
+    mask = groups.apply(
+        lambda c: ((c > 0).astype(np.int64).sum() / len(c)) >= threshold
+    ).values.T  # (n_genes, n_clusters)
 
     # (n_cells, n_genes)
     data = np.array(data[data.columns.difference(["clusters"])].values, dtype=np.float64, order="C")

--- a/src/squidpy/gr/_ligrec.py
+++ b/src/squidpy/gr/_ligrec.py
@@ -731,6 +731,7 @@ def _analysis(
 
         return TempResult(means=means, pvalues=pvalues)
 
+    data = data.astype(np.float64, copy=False)
     groups = data.groupby("clusters", observed=True)
     clustering = np.array(data["clusters"].values, dtype=np.int32)
 
@@ -739,7 +740,6 @@ def _analysis(
     # (n_cells, n_genes)
     data = np.array(data[data.columns.difference(["clusters"])].values, dtype=np.float64, order="C")
     # all 3 should be C contiguous
-
     return parallelize(  # type: ignore[no-any-return]
         _analysis_helper,
         np.arange(n_perms, dtype=np.int32).tolist(),

--- a/src/squidpy/gr/_ligrec.py
+++ b/src/squidpy/gr/_ligrec.py
@@ -735,7 +735,9 @@ def _analysis(
     clustering = np.array(data["clusters"].values, dtype=np.int32)
 
     mean = groups.mean().values.T  # (n_genes, n_clusters)
-    mask = groups.apply(lambda c: ((c > 0).astype(int).sum() / len(c)) >= threshold).values.T  # (n_genes, n_clusters)
+    # see https://github.com/scverse/squidpy/pull/991#issuecomment-2888506296
+    # for why we need to cast to int64 here
+    mask = groups.apply(lambda c: ((c > 0).astype(np.int64).sum() / len(c)) >= threshold).values.T  # (n_genes, n_clusters)
 
     # (n_cells, n_genes)
     data = np.array(data[data.columns.difference(["clusters"])].values, dtype=np.float64, order="C")

--- a/tests/graph/test_ligrec.py
+++ b/tests/graph/test_ligrec.py
@@ -473,5 +473,5 @@ class TestValidBehavior:
             copy=True,
         )
         expected_num_nans_upper = 500_000
-        num_nans = np.isnan(res['pvalues'].values).sum()
+        num_nans = np.isnan(res["pvalues"].values).sum()
         assert num_nans < expected_num_nans_upper

--- a/tests/graph/test_ligrec.py
+++ b/tests/graph/test_ligrec.py
@@ -461,3 +461,17 @@ class TestValidBehavior:
         )
         assert isinstance(pt.interactions, pd.DataFrame)
         assert len(pt.interactions) == 1
+
+    def test_pvalues_nans(self, adata_hne: AnnData):
+        res = ligrec(
+            adata_hne,
+            _CK,
+            seed=42,
+            n_perms=5,
+            show_progress_bar=False,
+            use_raw=False,
+            copy=True,
+        )
+        expected_num_nans_upper = 500_000
+        num_nans = np.isnan(res['pvalues'].values).sum()
+        assert num_nans < expected_num_nans_upper

--- a/tests/graph/test_ligrec.py
+++ b/tests/graph/test_ligrec.py
@@ -467,37 +467,67 @@ class TestValidBehavior:
         """
         For the test case with 2 clusters (A, B) and 3 gene pairs (Gene1→Gene2, Gene2→Gene3, Gene3→Gene1):
 
-        Expression fractions per cluster (computed as fraction of cells with value > 0):
-        Cluster A:
-        - Gene1: 1/3 = 0.33 (only A1 has value > 0)
-        - Gene2: 2/3 = 0.67 (A2 and A3 have value > 0)
-        - Gene3: 0/3 = 0.00 (none have value > 0)
-
-        Cluster B:
-        - Gene1: 1/3 = 0.33 (only B1 has value > 0)
-        - Gene2: 0/3 = 0.00 (none have value > 0)
-        - Gene3: 3/3 = 1.00 (all have value > 0)
-
         The mask is computed for each gene in each cluster as:
         mask[gene, cluster] = (number of cells with value > 0) / (total cells in cluster) >= threshold
 
-        With threshold=0.8, the mask is:
-        Cluster A: [False, False, False]  # All genes < 0.8 expression fraction
-        Cluster B: [False, False, True]   # Only Gene3 >= 0.8 expression fraction
+        Number of cells with value > 0 in each cluster:
+        Cluster A: [1, 3, 0]
+        Cluster B: [1, 0, 3]
+
+        Number of cells with value > 0 in each cluster divided by total number of cells in the cluster:
+        Cluster A: [1/3, 3/3, 0/3] = [0.33, 1.0, 0.0]
+        Cluster B: [1/3, 0/3, 3/3] = [0.33, 0.0, 1.0]
+
+        Using threshold=0.8 on this data, the mask is:
+        Cluster A: [False, True, False]
+        Cluster B: [False, False, True]
 
         A value in the result becomes NaN if either:
         - The ligand's mask is False in the source cluster, OR
         - The receptor's mask is False in the target cluster
 
-        For each cluster pair (A→A, A→B, B→A, B→B) and each gene pair:
-        A→A: All NaN (all genes have mask=False in A)
-        A→B: All NaN (all genes have mask=False in A)
-        B→A: All NaN (all genes have mask=False in A)
-        B→B: Only Gene2→Gene3 is non-NaN (Gene3 has mask=True in B)
+        Only in one combination, the mask is both True in the source and target cluster.
+        This is the case for Gene2→Gene3 in A→B.
 
-        Total NaNs = 4 cluster pairs x 3 gene pairs - 1 = 11 NaNs
-        (The -1 is because B→B for Gene2→Gene3 is the only non-NaN case, where Gene3 has mask=True in B)
+        This means from all the possible cluster pairs (A→A, A→B, B→A, B→B) and gene pairs (Gene1→Gene2, Gene2→Gene3, Gene3→Gene1),
+        (4 cluster pairs * 3 gene pairs = 12 combinations) only one combination is non-NaN.
+
+        Therefore, the total number of NaNs is 11.
+
+        The expected p-values are:
+        cluster_1        A         B
+        cluster_2        A    B    A    B
+        source target
+        GENE1  GENE2   NaN  NaN  NaN  NaN
+        GENE2  GENE3   NaN  0.0  NaN  NaN
+        GENE3  GENE1   NaN  NaN  NaN  NaN
+
         """
+        # only Gene2→Gene3 is non-NaN
+        #
+
+        expected_pvalues = np.array(
+            [
+                [
+                    np.nan,
+                    np.nan,
+                    np.nan,
+                    np.nan,
+                ],
+                [
+                    np.nan,
+                    0.0,
+                    np.nan,
+                    np.nan,
+                ],
+                [
+                    np.nan,
+                    np.nan,
+                    np.nan,
+                    np.nan,
+                ],
+            ]
+        )
 
         expected_nans = 11
         # Setup test data
@@ -532,3 +562,4 @@ class TestValidBehavior:
         actual_nans = np.sum(np.isnan(res["pvalues"].values))
 
         assert actual_nans == expected_nans, f"NaN count mismatch: expected {expected_nans}, got {actual_nans}"
+        np.testing.assert_array_equal(res["pvalues"].values, expected_pvalues)


### PR DESCRIPTION
Fixes https://github.com/scverse/squidpy/issues/871 and https://github.com/scverse/squidpy/issues/840

When comparing version 1.2.4 and main, I noticed 0's were integers while non zeros were floats in the main branch while in the old version they were all the float. I think this caused some rounding problems and integer divisions. I have some ideas on how to expose these bugs on unit tests but I just wanted to open this PR to show the fix.

Ligrec needs two things but I seperated the other to simplify this PR. Normally we also need to modify numba code because it doesn't parallelize due to an assertion exitting the loop early. Those changes are in this branch: https://github.com/scverse/squidpy/compare/main...fix/ligrec

The notebooks are now reproducable by my local tests. We used notebook tests on the CI in moscot, do you think we can also do this in squidpy @timtreis ?

