### PR TITLE
Deprecate Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["hatchling", "hatch-vcs", "hatch-fancy-pypi-readme"]
 name = "squidpy"
 dynamic = ["readme", "version"]
 description = "Spatial Single Cell Analysis in Python"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "BSD-3-Clause"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -16,9 +16,9 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Typing :: Typed",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Environment :: Console",
     "Framework :: Jupyter",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
Since python 3.10 is not supported by scientific-python.org/specs/spec-0000/#support-window the science community I will bump up the version. This was we can also use `fast-array-utils`