### PR TITLE
zarr v3 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
    "tqdm>=4.50.2",
    "validators>=0.18.2",
    "xarray>=2024.10.0",
-   "zarr>=2.6.1,<3.0.0",
+   "zarr>=2.6.1",
    "spatialdata>=0.2.5",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -376,7 +376,7 @@ def sdata_mask_graph():
         "region_key": "region",
         "instance_key": "instance_id",
     }
-    return sd.SpatialData.from_elements_dict(
+    return sd.SpatialData.init_from_elements(
         {
             "circles": sd.models.ShapesModel().parse(points_df),
             "polygon": sd.models.ShapesModel().parse(polygon_df),


### PR DESCRIPTION
**IMPORTANT: Please search among the [Pull requests](../pulls) before creating one.**

## Description

- removes `<3.0.0` constraint for the Zarr package (required for the incoming `spatialdata` release)
- replaces a method that was deprecated in `spatialdata` and that will be removed in the incoming release

## How has this been tested?

Subset of tests run locally (waiting for the CI tests to emit the status).

## Closes

Closes #1039 
