### PR TITLE
modified visium read function for reading tissue_positions.csv properly

### DIFF
--- a/src/squidpy/read/_read.py
+++ b/src/squidpy/read/_read.py
@@ -80,7 +80,9 @@ def visium(
 
     coords = pd.read_csv(
         tissue_positions_file,
-        header=1 if tissue_positions_file.name == "tissue_positions.csv" else None,
+        # if file name is tissue_positions.csv, then it has header, so use header=0. Else use
+        # header=None to assign colnames as 1,2,3... explicitly
+        header=0 if tissue_positions_file.name == "tissue_positions.csv" else None,
         index_col=0,
     )
     coords.columns = ["in_tissue", "array_row", "array_col", "pxl_col_in_fullres", "pxl_row_in_fullres"]


### PR DESCRIPTION
## Description

Modified visium read function (`squidpy.read.visium`) by correcting header argument of `pd.read_csv` when reading tissue_positions.csv (Ref: #1089). Earlier, it was reading the tissue_positions.csv with `pd.read_csv(file, header=1, ...)` which was leading to the second row of the csv being read as header, which skipped one row of data. Changing to header=0 makes it function as expected. I don't know why it was header=1 in the first place (my guess is likely there used to be an extra line in tissue_positions.csv earlier, which is not there in the outputs now):

```
$ head tissue_positions.csv
barcode,in_tissue,array_row,array_col,pxl_row_in_fullres,pxl_col_in_fullres
GTCACTTCCTTCTAGA-1,1,0,0,23891.771232682222,39028.97429208872
CACGGTCTCCTTACGA-1,1,0,2,23897.618791707442,38663.634433938605
ATAGCTGCGGATAAGA-1,1,0,4,23903.46462886722,38298.2952273851
GTCAGTATGTCCGGCG-1,1,0,6,23909.31218148734,37932.95571104603
ATGTACCAGTTACTCG-1,1,0,8,23915.159740512565,37567.615852895906
ACGCTCAGTGCACCGT-1,1,0,10,23921.00558727999,37202.276133625826
TCACTAACGTATAGTT-1,1,0,12,23926.853130292468,36836.93713000333
CGGTTAGGCCTGGACG-1,1,0,14,23932.699492979013,36471.59724943537
GATATCACCAGCATGG-1,1,0,16,23938.546539287658,36106.257381677606
```

## Closes

Closes #1089
