### PR TITLE
fix: Support SpaceRanger v3 format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,6 +151,7 @@ nitpick_ignore = [
     ("py:class", "squidpy._constants._constants.SpatialAutocorr"),
     ("py:class", "squidpy._constants._constants.CoordType"),
     ("py:class", "squidpy._constants._constants.Transform"),
+    ("py:class", "pandas.core.frame.DataFrame"),
 ]
 # see the solution from: https://github.com/sphinx-doc/sphinx/issues/7369
 linkcheck_ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ optional-dependencies.docs = [
   "sphinx-tabs",
   "sphinxcontrib-bibtex>=2.3",
   "sphinxcontrib-spelling>=7.6.2",
+  "docutils<0.22",  # Pin to avoid sphinx-tabs KeyError with backrefs
 ]
 optional-dependencies.leiden = [
   "leidenalg",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ optional-dependencies.dev = [
   "ruff",
 ]
 optional-dependencies.docs = [
+  "docutils<0.22",                    # Pin to avoid sphinx-tabs KeyError with backrefs
   "ipython",
   "ipywidgets>=8",
   "myst-nb>=0.17.1",
@@ -101,7 +102,6 @@ optional-dependencies.docs = [
   "sphinx-tabs",
   "sphinxcontrib-bibtex>=2.3",
   "sphinxcontrib-spelling>=7.6.2",
-  "docutils<0.22",  # Pin to avoid sphinx-tabs KeyError with backrefs
 ]
 optional-dependencies.leiden = [
   "leidenalg",

--- a/src/squidpy/read/_read.py
+++ b/src/squidpy/read/_read.py
@@ -85,7 +85,7 @@ def visium(
     # Detect header by checking if first cell is 'barcode' (header) or a barcode value
     with open(tissue_positions_file) as f:
         first_cell = f.readline().split(",")[0].strip()
-    has_header = first_cell == "barcode"
+    has_header = first_cell.lower() == "barcode"
 
     coords = pd.read_csv(
         tissue_positions_file,

--- a/src/squidpy/read/_read.py
+++ b/src/squidpy/read/_read.py
@@ -72,15 +72,24 @@ def visium(
         (path / f"{Key.uns.spatial}/scalefactors_json.json").read_bytes()
     )
 
+    # Space Ranger versions use different file formats:
+    #   - v1: tissue_positions.csv (no header)
+    #   - v2: tissue_positions_list.csv (with header)
+    #   - v3: tissue_positions.csv (with header)
     tissue_positions_file = (
         path / "spatial/tissue_positions.csv"
         if (path / "spatial/tissue_positions.csv").exists()
         else path / "spatial/tissue_positions_list.csv"
     )
 
+    # Detect header by checking if first cell is 'barcode' (header) or a barcode value
+    with open(tissue_positions_file) as f:
+        first_cell = f.readline().split(",")[0].strip()
+    has_header = first_cell == "barcode"
+
     coords = pd.read_csv(
         tissue_positions_file,
-        header=1 if tissue_positions_file.name == "tissue_positions.csv" else None,
+        header=0 if has_header else None,
         index_col=0,
     )
     coords.columns = ["in_tissue", "array_row", "array_col", "pxl_col_in_fullres", "pxl_row_in_fullres"]


### PR DESCRIPTION
fixes: https://github.com/scverse/squidpy/issues/1089

The format has a change in naming 

- v1: tissue_positions.csv (no header)
- v2: tissue_positions_list.csv (with header)
- v3: tissue_positions.csv (with header) (new)

Another change is header is set to 0 instead of 1. That was most likely a bug from https://github.com/scverse/squidpy/commit/03ee8faa12d1fc7fe2b8edb4386941a1c96f49ce but it didn't show up since the spaceranger v1 datasets are at scanpy and scanpy also uses `header=0` https://github.com/scverse/scanpy/blob/f75575cac1e7f8779b33cb5570bc9c726313fd1d/src/scanpy/readwrite.py#L504

