### PR TITLE
Fix: `_set_default_colors_for_categorical_obs` import fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,5 +145,4 @@ data
 .pixi
 pixi.lock
 
-# version file
 _version.py

--- a/src/squidpy/_compat.py
+++ b/src/squidpy/_compat.py
@@ -19,10 +19,9 @@ __all__ = [
     "SparseCSRView",
 ]
 
-# See https://github.com/scverse/squidpy/issues/1061 for more details
-# scanpy around version 0.11.x- 0.12.x changed the function name from set_default_colors_for_categorical_obs to _set_default_colors_for_categorical_obs
-# and then changed it back
-# so to not track with versioning we use the underscore version first (current), fall back to non-underscore for older/future versions
+# See https://github.com/scverse/squidpy/issues/1061 for more details.
+# Scanpy 0.11.x-0.12.x renamed set_default_colors_for_categorical_obs to _set_default_colors_for_categorical_obs
+# and then changed it back. Try underscore version first, fall back to non-underscore.
 try:
     from scanpy.plotting._utils import _set_default_colors_for_categorical_obs as set_default_colors_for_categorical_obs
 except ImportError:


### PR DESCRIPTION
Fixes https://github.com/scverse/squidpy/issues/1101

Also includes this commit https://github.com/scverse/squidpy/commit/9501a9ecfeb0814249ef6b9e501b79abf89ec385

I don't like using try except for logic but since the name of this function changed twice in a very short period I will go with the try except.

Added _version.py because some IDE's create it