### PR TITLE
Lower bound spatialdata>=1.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
   "scikit-image>=0.25",
   # due to https://github.com/scikit-image/scikit-image/issues/6850 breaks rescale ufunc
   "scikit-learn>=0.24",
-  "spatialdata>=0.7",
+  "spatialdata>=0.7.1",
   "spatialdata-plot",
   "statsmodels>=0.12",
   # https://github.com/scverse/squidpy/issues/526


### PR DESCRIPTION
Since dask-expr is deprecated there we better ~~lower bound it~~ switch to the version of spatialdata that no longer uses it. It works well with dask this way and doesn't give 

```
dask-expr 1.1.19 requires dask==2024.11.2, but you have dask 2026.1.2 which is incompatible.
```