### PR TITLE
fix: require spatialdata>=0.7.2 to drop the xarray-schema/pkg_resources break

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
   "scikit-image>=0.25",
   # due to https://github.com/scikit-image/scikit-image/issues/6850 breaks rescale ufunc
   "scikit-learn>=0.24",
-  "spatialdata>=0.7.1",
+  "spatialdata>=0.7.2",  # 0.7.2 dropped xarray-schema (pkg_resources break, #1115)
   "spatialdata-plot>=0.3.3",
   "statsmodels>=0.12",
   # https://github.com/scverse/squidpy/issues/526


### PR DESCRIPTION
Closes #1115.

`import squidpy` crashed on Python 3.12 / setuptools>=82 with `ModuleNotFoundError: No module named 'pkg_resources'`, traced into `xarray_schema` — pulled in transitively by spatialdata, which imported the removed `pkg_resources`.

spatialdata **0.7.2** dropped the `xarray-schema` dependency, so the proper fix is a lower-bound bump. The previous `>=0.7.1` floor (#1114) was set to drop `dask-expr` and still permits spatialdata 0.7.1, which keeps the bug.
