### PR TITLE
Compatibility layer for pandas3 changing fill_value for sparse from 0 to NaN

### DIFF
--- a/src/squidpy/gr/_ligrec.py
+++ b/src/squidpy/gr/_ligrec.py
@@ -212,9 +212,7 @@ class PermutationTestABC(ABC):
             adata = adata.raw
 
         self._data = _fix_sparse_fill_value(
-            pd.DataFrame.sparse.from_spmatrix(
-                csc_matrix(adata.X), index=adata.obs_names, columns=adata.var_names
-            )
+            pd.DataFrame.sparse.from_spmatrix(csc_matrix(adata.X), index=adata.obs_names, columns=adata.var_names)
         )
 
         self._interactions: pd.DataFrame | None = None

--- a/src/squidpy/gr/_ligrec.py
+++ b/src/squidpy/gr/_ligrec.py
@@ -26,6 +26,7 @@ from squidpy.gr._utils import (
     _assert_positive,
     _check_tuple_needles,
     _create_sparse_df,
+    _fix_sparse_fill_value,
     _genesymbols,
     _save_data,
 )
@@ -210,8 +211,10 @@ class PermutationTestABC(ABC):
                 raise ValueError(f"Expected `{adata.n_obs}` cells in `.raw` object, found `{adata.raw.n_obs}`.")
             adata = adata.raw
 
-        self._data = pd.DataFrame.sparse.from_spmatrix(
-            csc_matrix(adata.X), index=adata.obs_names, columns=adata.var_names
+        self._data = _fix_sparse_fill_value(
+            pd.DataFrame.sparse.from_spmatrix(
+                csc_matrix(adata.X), index=adata.obs_names, columns=adata.var_names
+            )
         )
 
         self._interactions: pd.DataFrame | None = None

--- a/src/squidpy/gr/_utils.py
+++ b/src/squidpy/gr/_utils.py
@@ -146,8 +146,7 @@ def _fix_sparse_fill_value(df: pd.DataFrame) -> pd.DataFrame:
     reused; only the fill-value scalar is updated.
     """
     needs_fix = any(
-        isinstance(df[c].array, pd.arrays.SparseArray) and np.isnan(df[c].array.fill_value)
-        for c in df.columns
+        isinstance(df[c].array, pd.arrays.SparseArray) and np.isnan(df[c].array.fill_value) for c in df.columns
     )
     if not needs_fix:
         return df


### PR DESCRIPTION
pandas 3.0 changed `DataFrame.sparse.from_spmatrix` to use `fill_value=NaN` instead of `fill_value=0` for float columns (pandas PR #59064). With `fill_value=NaN`, `groupby().mean()` excludes those zeros from the denominator, inflating means and producing wrong results in ligrec.

The fix wraps the `from_spmatrix` call in `PermutationTestABC.__init__` with a small helper that resets any `fill_value=NaN` sparse columns back to `fill_value=0`. It's skipped on pandas <3.