### PR TITLE
chore: replace normalize_per_cell to avoid warnings in CI's

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,8 @@ def adata_squaregrid() -> AnnData:
 def paul15() -> AnnData:
     # session because we don't modify this dataset
     adata = sc.datasets.paul15()
-    sc.pp.normalize_per_cell(adata)
+    sc.pp.filter_cells(adata, min_counts=1)
+    sc.pp.normalize_total(adata)
     adata.raw = adata.copy()
 
     return adata


### PR DESCRIPTION
Replaces the deprecated function normalize_per_cell usage with normalize_total + filter_cells. This reduces the number of warnings in the ci