### PR TITLE
ci: pin virtualenv<21 to fix hatch incompatibility

### DIFF
--- a/.github/uv-constraints.txt
+++ b/.github/uv-constraints.txt
@@ -1,0 +1,2 @@
+# TODO: remove once hatch is compatible with virtualenv 21+ (pypa/hatch#2193)
+virtualenv<21

--- a/.github/workflows/test-notebooks.yaml
+++ b/.github/workflows/test-notebooks.yaml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # TODO: remove once hatch is compatible with virtualenv 21+ (pypa/hatch#2193)
+  UV_CONSTRAINT: ${{ github.workspace }}/.github/uv-constraints.txt
+
 jobs:
   ensure-data-is-cached:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,8 @@ env:
   MPLBACKEND: agg
   UV_COMPILE_BYTECODE: "1"
   COVERAGE_FILE: ${{ github.workspace }}/.coverage
+  # TODO: remove once hatch is compatible with virtualenv 21+ (pypa/hatch#2193)
+  UV_CONSTRAINT: ${{ github.workspace }}/.github/uv-constraints.txt
 
 defaults:
   run:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,8 @@ build:
       - asdf global uv latest
     build:
       html:
-        - uvx hatch run docs:build
+        # TODO: remove UV_CONSTRAINT once hatch is compatible with virtualenv 21+ (pypa/hatch#2193)
+        - UV_CONSTRAINT=$READTHEDOCS_REPOSITORY_PATH/.github/uv-constraints.txt uvx hatch run docs:build
         - mv docs/_build $READTHEDOCS_OUTPUT
 
 submodules:


### PR DESCRIPTION
## Summary
- virtualenv 21.0 removed `propose_interpreters` from `virtualenv.discovery.builtin`, breaking hatch's environment checks ([pypa/hatch#2193](https://github.com/pypa/hatch/issues/2193))
- Adds `.github/uv-constraints.txt` with `virtualenv<21` and sets `UV_CONSTRAINT` in both `test.yaml` and `test-notebooks.yaml`
- TODO comments mark these for removal once hatch releases a fix

## Test plan
- CI should pass on this PR (the constraint file is checked out before any `uvx hatch` calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)