### PR TITLE
Add explicit error handling in _make_tiles.py

### DIFF
--- a/src/squidpy/experimental/im/_make_tiles.py
+++ b/src/squidpy/experimental/im/_make_tiles.py
@@ -359,7 +359,6 @@ def make_tiles(
     make_tiles_from_spots
         Create tiles centered on Visium spots instead of a regular grid.
     """
-    # --- upfront parameter validation ---
     if image_key not in sdata.images:
         raise KeyError(f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}")
     if tile_size[0] <= 0 or tile_size[1] <= 0:

--- a/src/squidpy/experimental/im/_make_tiles.py
+++ b/src/squidpy/experimental/im/_make_tiles.py
@@ -171,9 +171,7 @@ def _get_largest_scale_dimensions(
 ) -> tuple[int, int]:
     """Get the dimensions (H, W) of the largest/finest scale of an image."""
     if image_key not in sdata.images:
-        raise KeyError(
-            f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}"
-        )
+        raise KeyError(f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}")
     img_node = sdata.images[image_key]
 
     # Use _get_element_data with "scale0" which is always the largest scale
@@ -363,9 +361,7 @@ def make_tiles(
     """
     # --- upfront parameter validation ---
     if image_key not in sdata.images:
-        raise KeyError(
-            f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}"
-        )
+        raise KeyError(f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}")
     if tile_size[0] <= 0 or tile_size[1] <= 0:
         raise ValueError(f"tile_size must have positive values, got {tile_size}.")
     if not 0 <= min_tissue_fraction <= 1:
@@ -540,9 +536,7 @@ def make_tiles_from_spots(
     if spots_key not in sdata.shapes:
         raise KeyError(f"Spots key '{spots_key}' not found in sdata.shapes")
     if image_key is not None and image_key not in sdata.images:
-        raise KeyError(
-            f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}"
-        )
+        raise KeyError(f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}")
     if not 0 <= min_tissue_fraction <= 1:
         raise ValueError(f"min_tissue_fraction must be in [0, 1], got {min_tissue_fraction}.")
 
@@ -850,9 +844,7 @@ def _get_spot_coordinates(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Extract spot centers (x, y) and IDs from a shapes table."""
     if spots_key not in sdata.shapes:
-        raise KeyError(
-            f"Spots key '{spots_key}' not found in sdata.shapes. Available: {list(sdata.shapes.keys())}"
-        )
+        raise KeyError(f"Spots key '{spots_key}' not found in sdata.shapes. Available: {list(sdata.shapes.keys())}")
     gdf = sdata.shapes[spots_key]
     if "geometry" not in gdf:
         raise ValueError(f"Shapes '{spots_key}' lack geometry column required for spot coordinates.")

--- a/src/squidpy/experimental/im/_make_tiles.py
+++ b/src/squidpy/experimental/im/_make_tiles.py
@@ -857,10 +857,7 @@ def _get_spot_coordinates(
 
 def _get_primary_coordinate_system(element: SpatialElement) -> str | None:
     """Return the first available coordinate system, preferring 'global'."""
-    try:
-        transformations = get_transformation(element, get_all=True)
-    except (KeyError, ValueError):
-        return None
+    transformations = get_transformation(element, get_all=True)
     if not transformations:
         return None
     # Prefer 'global' if present

--- a/src/squidpy/experimental/im/_make_tiles.py
+++ b/src/squidpy/experimental/im/_make_tiles.py
@@ -170,6 +170,10 @@ def _get_largest_scale_dimensions(
     image_key: str,
 ) -> tuple[int, int]:
     """Get the dimensions (H, W) of the largest/finest scale of an image."""
+    if image_key not in sdata.images:
+        raise KeyError(
+            f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}"
+        )
     img_node = sdata.images[image_key]
 
     # Use _get_element_data with "scale0" which is always the largest scale
@@ -357,6 +361,16 @@ def make_tiles(
     make_tiles_from_spots
         Create tiles centered on Visium spots instead of a regular grid.
     """
+    # --- upfront parameter validation ---
+    if image_key not in sdata.images:
+        raise KeyError(
+            f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}"
+        )
+    if tile_size[0] <= 0 or tile_size[1] <= 0:
+        raise ValueError(f"tile_size must have positive values, got {tile_size}.")
+    if not 0 <= min_tissue_fraction <= 1:
+        raise ValueError(f"min_tissue_fraction must be in [0, 1], got {min_tissue_fraction}.")
+
     # Derive mask key for centering if needed
     mask_key_for_grid = image_mask_key
     default_mask_key = tissue_mask_key or f"{image_key}_tissue"
@@ -525,6 +539,12 @@ def make_tiles_from_spots(
 
     if spots_key not in sdata.shapes:
         raise KeyError(f"Spots key '{spots_key}' not found in sdata.shapes")
+    if image_key is not None and image_key not in sdata.images:
+        raise KeyError(
+            f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}"
+        )
+    if not 0 <= min_tissue_fraction <= 1:
+        raise ValueError(f"min_tissue_fraction must be in [0, 1], got {min_tissue_fraction}.")
 
     target_cs: str | None = None
     if image_key is not None:
@@ -829,6 +849,10 @@ def _get_spot_coordinates(
     spots_key: str,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Extract spot centers (x, y) and IDs from a shapes table."""
+    if spots_key not in sdata.shapes:
+        raise KeyError(
+            f"Spots key '{spots_key}' not found in sdata.shapes. Available: {list(sdata.shapes.keys())}"
+        )
     gdf = sdata.shapes[spots_key]
     if "geometry" not in gdf:
         raise ValueError(f"Shapes '{spots_key}' lack geometry column required for spot coordinates.")

--- a/tests/experimental/test_make_tiles.py
+++ b/tests/experimental/test_make_tiles.py
@@ -151,6 +151,4 @@ def test_make_tiles_from_spots_invalid_spots_key(sdata_hne):
 def test_make_tiles_from_spots_invalid_image_key(sdata_hne):
     """make_tiles_from_spots raises KeyError for a missing image key."""
     with pytest.raises(KeyError, match="not found in sdata.images"):
-        sq.experimental.im.make_tiles_from_spots(
-            sdata_hne, spots_key="spots", image_key="nonexistent", preview=False
-        )
+        sq.experimental.im.make_tiles_from_spots(sdata_hne, spots_key="spots", image_key="nonexistent", preview=False)

--- a/tests/experimental/test_make_tiles.py
+++ b/tests/experimental/test_make_tiles.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pytest
 import spatialdata_plot as sdp
 from spatialdata.transformations import Identity, get_transformation, set_transformation
 
@@ -122,33 +121,3 @@ def test_make_tiles_copies_image_transformations(sdata_hne):
     assert "custom_cs" in img_tfs and "custom_cs" in tile_tfs
     assert isinstance(img_tfs["custom_cs"], Identity)
     assert isinstance(tile_tfs["custom_cs"], Identity)
-
-
-def test_make_tiles_invalid_image_key(sdata_hne):
-    """make_tiles raises KeyError for a missing image key."""
-    with pytest.raises(KeyError, match="not found in sdata.images"):
-        sq.experimental.im.make_tiles(sdata_hne, image_key="nonexistent", preview=False)
-
-
-def test_make_tiles_invalid_tile_size(sdata_hne):
-    """make_tiles raises ValueError for non-positive tile size."""
-    with pytest.raises(ValueError, match="tile_size must have positive values"):
-        sq.experimental.im.make_tiles(sdata_hne, image_key="hne", tile_size=(0, 224), preview=False)
-
-
-def test_make_tiles_invalid_min_tissue_fraction(sdata_hne):
-    """make_tiles raises ValueError for out-of-range min_tissue_fraction."""
-    with pytest.raises(ValueError, match="min_tissue_fraction must be in"):
-        sq.experimental.im.make_tiles(sdata_hne, image_key="hne", min_tissue_fraction=1.5, preview=False)
-
-
-def test_make_tiles_from_spots_invalid_spots_key(sdata_hne):
-    """make_tiles_from_spots raises KeyError for a missing spots key."""
-    with pytest.raises(KeyError, match="not found in sdata.shapes"):
-        sq.experimental.im.make_tiles_from_spots(sdata_hne, spots_key="nonexistent", preview=False)
-
-
-def test_make_tiles_from_spots_invalid_image_key(sdata_hne):
-    """make_tiles_from_spots raises KeyError for a missing image key."""
-    with pytest.raises(KeyError, match="not found in sdata.images"):
-        sq.experimental.im.make_tiles_from_spots(sdata_hne, spots_key="spots", image_key="nonexistent", preview=False)

--- a/tests/experimental/test_make_tiles.py
+++ b/tests/experimental/test_make_tiles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 import spatialdata_plot as sdp
 from spatialdata.transformations import Identity, get_transformation, set_transformation
 
@@ -121,3 +122,35 @@ def test_make_tiles_copies_image_transformations(sdata_hne):
     assert "custom_cs" in img_tfs and "custom_cs" in tile_tfs
     assert isinstance(img_tfs["custom_cs"], Identity)
     assert isinstance(tile_tfs["custom_cs"], Identity)
+
+
+def test_make_tiles_invalid_image_key(sdata_hne):
+    """make_tiles raises KeyError for a missing image key."""
+    with pytest.raises(KeyError, match="not found in sdata.images"):
+        sq.experimental.im.make_tiles(sdata_hne, image_key="nonexistent", preview=False)
+
+
+def test_make_tiles_invalid_tile_size(sdata_hne):
+    """make_tiles raises ValueError for non-positive tile size."""
+    with pytest.raises(ValueError, match="tile_size must have positive values"):
+        sq.experimental.im.make_tiles(sdata_hne, image_key="hne", tile_size=(0, 224), preview=False)
+
+
+def test_make_tiles_invalid_min_tissue_fraction(sdata_hne):
+    """make_tiles raises ValueError for out-of-range min_tissue_fraction."""
+    with pytest.raises(ValueError, match="min_tissue_fraction must be in"):
+        sq.experimental.im.make_tiles(sdata_hne, image_key="hne", min_tissue_fraction=1.5, preview=False)
+
+
+def test_make_tiles_from_spots_invalid_spots_key(sdata_hne):
+    """make_tiles_from_spots raises KeyError for a missing spots key."""
+    with pytest.raises(KeyError, match="not found in sdata.shapes"):
+        sq.experimental.im.make_tiles_from_spots(sdata_hne, spots_key="nonexistent", preview=False)
+
+
+def test_make_tiles_from_spots_invalid_image_key(sdata_hne):
+    """make_tiles_from_spots raises KeyError for a missing image key."""
+    with pytest.raises(KeyError, match="not found in sdata.images"):
+        sq.experimental.im.make_tiles_from_spots(
+            sdata_hne, spots_key="spots", image_key="nonexistent", preview=False
+        )


### PR DESCRIPTION
## Summary
- Adds upfront parameter validation with clear `KeyError`/`ValueError` messages to `make_tiles()`, `make_tiles_from_spots()`, `_get_largest_scale_dimensions()`, and `_get_spot_coordinates()`
- Validates that image/spots keys exist in `sdata`, `tile_size` has positive values, and `min_tissue_fraction` is in [0, 1]
- Adds 5 test cases covering all new error conditions

Closes #1086

## Test plan
- [x] `test_make_tiles_invalid_image_key` — bad image key raises `KeyError`
- [x] `test_make_tiles_invalid_tile_size` — non-positive tile size raises `ValueError`
- [x] `test_make_tiles_invalid_min_tissue_fraction` — out-of-range fraction raises `ValueError`
- [x] `test_make_tiles_from_spots_invalid_spots_key` — bad spots key raises `KeyError`
- [x] `test_make_tiles_from_spots_invalid_image_key` — bad image key raises `KeyError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)