### PR TITLE
Replace manual variable checks with wrapper functions

### DIFF
--- a/src/squidpy/_utils.py
+++ b/src/squidpy/_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import inspect
 import warnings
-from collections.abc import Callable, Generator, Hashable, Iterable, Sequence
+from collections.abc import Callable, Collection, Generator, Hashable, Iterable, Sequence
 from contextlib import contextmanager
 from enum import Enum
 from multiprocessing import Manager, cpu_count
@@ -56,6 +56,19 @@ def _unique_order_preserving(
     seen: set[Hashable] = set()
     seen_add = seen.add
     return [i for i in iterable if not (i in seen or seen_add(i))], seen
+
+
+def _assert_in(value: Any, *, name: str, collection: Collection[Any]) -> None:
+    """Assert that ``value`` is in ``collection``."""
+    if value not in collection:
+        raise ValueError(f"Expected `{name}` to be one of `{sorted(collection)}`, found `{value!r}`.")
+
+
+def _assert_key_exists(key: str, *, container: Any, container_name: str) -> None:
+    """Assert that ``key`` exists in ``container``."""
+    if key not in container:
+        available = sorted(container.keys()) if hasattr(container, "keys") else sorted(container)
+        raise KeyError(f"Key `{key!r}` not found in `{container_name}`. Available keys: `{available}`.")
 
 
 def _callback_wrapper(chosen_runner: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:

--- a/src/squidpy/datasets/_registry.py
+++ b/src/squidpy/datasets/_registry.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from squidpy._utils import _assert_key_exists
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from importlib.resources.abc import Traversable
@@ -144,8 +146,7 @@ class DatasetRegistry:
 
     def __getitem__(self, name: str) -> DatasetEntry:
         """Get a dataset by name, raises KeyError if not found."""
-        if name not in self.datasets:
-            raise KeyError(f"Unknown dataset: {name}. Available: {list(self.datasets.keys())}")
+        _assert_key_exists(name, container=self.datasets, container_name="datasets")
         return self.datasets[name]
 
     def __contains__(self, name: str) -> bool:

--- a/src/squidpy/experimental/im/_make_tiles.py
+++ b/src/squidpy/experimental/im/_make_tiles.py
@@ -16,7 +16,7 @@ from spatialdata.models import Labels2DModel, ShapesModel
 from spatialdata.models._utils import SpatialElement
 from spatialdata.transformations import get_transformation, set_transformation
 
-from squidpy._utils import _yx_from_shape
+from squidpy._utils import _assert_key_exists, _yx_from_shape
 
 from ._utils import _get_element_data
 
@@ -170,8 +170,7 @@ def _get_largest_scale_dimensions(
     image_key: str,
 ) -> tuple[int, int]:
     """Get the dimensions (H, W) of the largest/finest scale of an image."""
-    if image_key not in sdata.images:
-        raise KeyError(f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}")
+    _assert_key_exists(image_key, container=sdata.images, container_name="sdata.images")
     img_node = sdata.images[image_key]
 
     # Use _get_element_data with "scale0" which is always the largest scale
@@ -359,8 +358,7 @@ def make_tiles(
     make_tiles_from_spots
         Create tiles centered on Visium spots instead of a regular grid.
     """
-    if image_key not in sdata.images:
-        raise KeyError(f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}")
+    _assert_key_exists(image_key, container=sdata.images, container_name="sdata.images")
     if tile_size[0] <= 0 or tile_size[1] <= 0:
         raise ValueError(f"tile_size must have positive values, got {tile_size}.")
     if not 0 <= min_tissue_fraction <= 1:
@@ -431,8 +429,7 @@ def make_tiles(
                 )
             except (ImportError, KeyError, ValueError, RuntimeError) as e:  # pragma: no cover - defensive
                 logger.warning("detect_tissue failed (%s); tiles will not be classified.", e)
-        if classification_mask_key not in sdata.labels:
-            raise KeyError(f"Tissue mask '{classification_mask_key}' not found in sdata.labels.")
+        _assert_key_exists(classification_mask_key, container=sdata.labels, container_name="sdata.labels")
         # Use a mask scale that aligns with the full-resolution image; avoid coarsest "auto" selection.
         if scale == "auto":
             label_node = sdata.labels.get(classification_mask_key)
@@ -532,10 +529,9 @@ def make_tiles_from_spots(
         Helper used to derive tissue masks automatically when needed.
     """
 
-    if spots_key not in sdata.shapes:
-        raise KeyError(f"Spots key '{spots_key}' not found in sdata.shapes")
-    if image_key is not None and image_key not in sdata.images:
-        raise KeyError(f"Image key '{image_key}' not found in sdata.images. Available: {list(sdata.images.keys())}")
+    _assert_key_exists(spots_key, container=sdata.shapes, container_name="sdata.shapes")
+    if image_key is not None:
+        _assert_key_exists(image_key, container=sdata.images, container_name="sdata.images")
     if not 0 <= min_tissue_fraction <= 1:
         raise ValueError(f"min_tissue_fraction must be in [0, 1], got {min_tissue_fraction}.")
 
@@ -585,8 +581,7 @@ def make_tiles_from_spots(
 
     if classification_mask_key is not None:
         if image_key is not None:
-            if image_key not in sdata.images:
-                raise KeyError(f"Image key '{image_key}' not found in sdata.images")
+            _assert_key_exists(image_key, container=sdata.images, container_name="sdata.images")
 
             mask_key = classification_mask_key
             if mask_key in sdata.labels:
@@ -605,8 +600,7 @@ def make_tiles_from_spots(
                 shapes_key=shapes_key,
             )
         else:
-            if classification_mask_key not in sdata.labels:
-                raise KeyError(f"Tissue mask '{classification_mask_key}' not found in sdata.labels.")
+            _assert_key_exists(classification_mask_key, container=sdata.labels, container_name="sdata.labels")
             # Without an image we cannot infer the best scale; default to finest scale unless user specified.
             scale_used = "scale0" if scale == "auto" else scale
             _filter_tiles(
@@ -697,8 +691,7 @@ def _filter_tiles(
         mask_key = f"{image_key}_tissue"
     else:
         raise ValueError("tissue_mask_key must be provided when image_key is None.")
-    if mask_key not in sdata.labels:
-        raise KeyError(f"Tissue mask '{mask_key}' not found in sdata.labels.")
+    _assert_key_exists(mask_key, container=sdata.labels, container_name="sdata.labels")
     mask = _get_mask_from_labels(sdata, mask_key, scale)
     H_mask, W_mask = mask.shape
 
@@ -767,8 +760,7 @@ def _make_tiles(
 ) -> _TileGrid:
     """Construct a tile grid for an image, optionally centered on a tissue mask."""
     # Validate image key
-    if image_key not in sdata.images:
-        raise KeyError(f"Image key '{image_key}' not found in sdata.images")
+    _assert_key_exists(image_key, container=sdata.images, container_name="sdata.images")
 
     # Get image dimensions from the largest/finest scale
     H, W = _get_largest_scale_dimensions(sdata, image_key)
@@ -780,10 +772,7 @@ def _make_tiles(
         return _TileGrid(H, W, tile_size=tile_size)
 
     # Path 2: Center grid on tissue mask centroid
-    if image_mask_key not in sdata.labels:
-        raise KeyError(
-            f"Mask key '{image_mask_key}' not found in sdata.labels. Available keys: {list(sdata.labels.keys())}"
-        )
+    _assert_key_exists(image_mask_key, container=sdata.labels, container_name="sdata.labels")
 
     # Get mask and compute centroid
     label_node = sdata.labels[image_mask_key]
@@ -842,8 +831,7 @@ def _get_spot_coordinates(
     spots_key: str,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Extract spot centers (x, y) and IDs from a shapes table."""
-    if spots_key not in sdata.shapes:
-        raise KeyError(f"Spots key '{spots_key}' not found in sdata.shapes. Available: {list(sdata.shapes.keys())}")
+    _assert_key_exists(spots_key, container=sdata.shapes, container_name="sdata.shapes")
     gdf = sdata.shapes[spots_key]
     if "geometry" not in gdf:
         raise ValueError(f"Shapes '{spots_key}' lack geometry column required for spot coordinates.")
@@ -893,8 +881,7 @@ def _derive_tile_size_from_spots(coords: np.ndarray) -> tuple[int, int]:
 
 def _get_mask_from_labels(sdata: sd.SpatialData, mask_key: str, scale: str) -> np.ndarray:
     """Extract a 2D mask array from ``sdata.labels`` at the requested scale."""
-    if mask_key not in sdata.labels:
-        raise KeyError(f"Mask key '{mask_key}' not found in sdata.labels")
+    _assert_key_exists(mask_key, container=sdata.labels, container_name="sdata.labels")
 
     label_node = sdata.labels[mask_key]
     mask_da = _get_element_data(label_node, scale, "label", mask_key)

--- a/src/squidpy/gr/_ligrec.py
+++ b/src/squidpy/gr/_ligrec.py
@@ -20,7 +20,7 @@ from spatialdata import SpatialData
 from squidpy._constants._constants import ComplexPolicy, CorrAxis
 from squidpy._constants._pkg_constants import Key
 from squidpy._docs import d, inject_docs
-from squidpy._utils import NDArrayA, Signal, SigQueue, _get_n_cores, parallelize
+from squidpy._utils import NDArrayA, Signal, SigQueue, _assert_key_exists, _get_n_cores, parallelize
 from squidpy.gr._utils import (
     _assert_categorical_obs,
     _assert_positive,
@@ -256,10 +256,8 @@ class PermutationTestABC(ABC):
             interactions = pd.DataFrame(interactions)
 
         if isinstance(interactions, pd.DataFrame):
-            if SOURCE not in interactions.columns:
-                raise KeyError(f"Column `{SOURCE!r}` is not in `interactions`.")
-            if TARGET not in interactions.columns:
-                raise KeyError(f"Column `{TARGET!r}` is not in `interactions`.")
+            _assert_key_exists(SOURCE, container=interactions.columns, container_name="interactions.columns")
+            _assert_key_exists(TARGET, container=interactions.columns, container_name="interactions.columns")
 
             self._interactions = interactions.copy()
         elif isinstance(interactions, Iterable):

--- a/src/squidpy/gr/_niche.py
+++ b/src/squidpy/gr/_niche.py
@@ -20,6 +20,7 @@ from spatialdata._logging import logger as logg
 
 from squidpy._constants._constants import NicheDefinitions
 from squidpy._docs import d, inject_docs
+from squidpy._utils import _assert_in, _assert_key_exists
 
 __all__ = ["calculate_niche"]
 
@@ -175,17 +176,10 @@ def calculate_niche(
         orig_adata = data
         adata = data.copy()
 
-    if spatial_connectivities_key not in adata.obsp.keys():
-        raise KeyError(
-            f"Key '{spatial_connectivities_key}' not found in `adata.obsp`. "
-            "If you haven't computed a spatial neighborhood graph yet, use `sq.gr.spatial_neighbors`."
-        )
+    _assert_key_exists(spatial_connectivities_key, container=adata.obsp, container_name="adata.obsp")
 
-    if flavor == "spatialleiden" and (latent_connectivities_key not in adata.obsp.keys()):
-        raise KeyError(
-            f"Key '{latent_connectivities_key}' not found in `adata.obsp`. "
-            "If you haven't computed a latent neighborhood graph yet, use `sc.pp.neighbors`."
-        )
+    if flavor == "spatialleiden":
+        _assert_key_exists(latent_connectivities_key, container=adata.obsp, container_name="adata.obsp")
 
     result_columns = _get_result_columns(
         flavor=flavor,
@@ -572,10 +566,7 @@ def _get_cellcharter_niches(
 
     if use_rep is not None:
         # Use provided embedding from adata.obsm
-        if use_rep not in adata.obsm:
-            raise KeyError(
-                f"Embedding key '{use_rep}' not found in adata.obsm. Available keys: {list(adata.obsm.keys())}"
-            )
+        _assert_key_exists(use_rep, container=adata.obsm, container_name="adata.obsm")
         embedding = adata.obsm[use_rep]
         # Ensure embedding has the right number of components
         if embedding.shape[1] < n_components:
@@ -842,10 +833,7 @@ def _validate_niche_args(
     if not isinstance(data, AnnData | SpatialData):
         raise TypeError(f"'data' must be an AnnData or SpatialData object, got {type(data).__name__}")
 
-    if flavor not in ["neighborhood", "utag", "cellcharter", "spatialleiden"]:
-        raise ValueError(
-            f"Invalid flavor '{flavor}'. Please choose one of 'neighborhood', 'utag', 'cellcharter', 'spatialleiden'."
-        )
+    _assert_in(flavor, name="flavor", collection=["neighborhood", "utag", "cellcharter", "spatialleiden"])
 
     if library_key is not None:
         if not isinstance(library_key, str):
@@ -993,8 +981,7 @@ def _validate_niche_args(
 
         if aggregation is not None and not isinstance(aggregation, str):
             raise TypeError(f"'aggregation' must be a string, got {type(aggregation).__name__}")
-        if aggregation not in ["mean", "variance"]:
-            raise ValueError(f"'aggregation' must be one of 'mean' or 'variance', got {aggregation}")
+        _assert_in(aggregation, name="aggregation", collection=["mean", "variance"])
 
         if not isinstance(n_components, int):
             raise TypeError(f"'n_components' must be an integer, got {type(n_components).__name__}")

--- a/src/squidpy/gr/_ppatterns.py
+++ b/src/squidpy/gr/_ppatterns.py
@@ -23,7 +23,7 @@ from statsmodels.stats.multitest import multipletests
 from squidpy._constants._constants import SpatialAutocorr
 from squidpy._constants._pkg_constants import Key
 from squidpy._docs import d, inject_docs
-from squidpy._utils import NDArrayA, Signal, SigQueue, _get_n_cores, parallelize
+from squidpy._utils import NDArrayA, Signal, SigQueue, _assert_key_exists, _get_n_cores, parallelize
 from squidpy.gr._utils import (
     _assert_categorical_obs,
     _assert_connectivity_key,
@@ -158,8 +158,7 @@ def spatial_autocorr(
         return adata.obs[cols].T.to_numpy(), cols
 
     def extract_obsm(adata: AnnData, ixs: int | Sequence[int] | None) -> tuple[NDArrayA | spmatrix, Sequence[Any]]:
-        if layer not in adata.obsm:
-            raise KeyError(f"Key `{layer!r}` not found in `adata.obsm`.")
+        _assert_key_exists(layer, container=adata.obsm, container_name="adata.obsm")
         if ixs is None:
             ixs = list(np.arange(adata.obsm[layer].shape[1]))
         ixs = list(np.ravel([ixs]))

--- a/src/squidpy/gr/_sepal.py
+++ b/src/squidpy/gr/_sepal.py
@@ -14,7 +14,7 @@ from spatialdata import SpatialData
 
 from squidpy._constants._pkg_constants import Key
 from squidpy._docs import d, inject_docs
-from squidpy._utils import NDArrayA, Signal, SigQueue, _get_n_cores, parallelize
+from squidpy._utils import NDArrayA, Signal, SigQueue, _assert_in, _get_n_cores, parallelize
 from squidpy.gr._utils import (
     _assert_connectivity_key,
     _assert_non_empty_sequence,
@@ -97,8 +97,7 @@ def sepal(
         adata = adata.table
     _assert_connectivity_key(adata, connectivity_key)
     _assert_spatial_basis(adata, key=spatial_key)
-    if max_neighs not in (4, 6):
-        raise ValueError(f"Expected `max_neighs` to be either `4` or `6`, found `{max_neighs}`.")
+    _assert_in(max_neighs, name="max_neighs", collection=(4, 6))
 
     spatial = adata.obsm[spatial_key].astype(np.float64)
 

--- a/src/squidpy/im/_container.py
+++ b/src/squidpy/im/_container.py
@@ -26,7 +26,7 @@ from skimage.util import img_as_float
 from squidpy._constants._constants import InferDimensions
 from squidpy._constants._pkg_constants import Key
 from squidpy._docs import d, inject_docs
-from squidpy._utils import NDArrayA, singledispatchmethod
+from squidpy._utils import NDArrayA, _assert_key_exists, singledispatchmethod
 from squidpy.gr._utils import (
     _assert_in_range,
     _assert_non_empty_sequence,
@@ -313,8 +313,7 @@ class ImageContainer(FeatureMixin):
     @singledispatchmethod
     def _load_img(self, img: Pathlike_t | Input_t | ImageContainer, layer: str, **kwargs: Any) -> xr.DataArray | None:
         if isinstance(img, ImageContainer):
-            if layer not in img:
-                raise KeyError(f"Image identifier `{layer}` not found in `{img}`.")
+            _assert_key_exists(layer, container=img, container_name=str(img))
 
             _ = kwargs.pop("dims", None)
             return self._load_img(img[layer], **kwargs)
@@ -1406,8 +1405,7 @@ class ImageContainer(FeatureMixin):
                 )
             library_id = self.library_ids[0]
 
-        if library_id not in self.library_ids:
-            raise KeyError(f"Library id `{library_id}` not found in `{self.library_ids}`.")
+        _assert_key_exists(library_id, container=self.library_ids, container_name="library_ids")
 
         return library_id
 
@@ -1470,8 +1468,7 @@ class ImageContainer(FeatureMixin):
                     f"Unable to determine which layer to use. Please supply one from `{sorted(self.data.keys())}`."
                 )
             layer = list(self)[0]
-        if layer not in self:
-            raise KeyError(f"Image layer `{layer}` not found in `{sorted(self)}`.")
+        _assert_key_exists(layer, container=self, container_name="image layers")
 
         return layer
 

--- a/src/squidpy/im/_feature_mixin.py
+++ b/src/squidpy/im/_feature_mixin.py
@@ -11,7 +11,7 @@ from skimage.util import img_as_ubyte
 
 from squidpy._constants._pkg_constants import Key
 from squidpy._docs import d
-from squidpy._utils import NDArrayA
+from squidpy._utils import NDArrayA, _assert_in
 from squidpy.gr._utils import _assert_non_empty_sequence
 from squidpy.im._coords import _NULL_PADDING, CropCoords
 
@@ -30,8 +30,7 @@ def _get_channels(xr_img: NDArrayA | xr.DataArray, channels: Channel_t | None) -
         channels = [channels]
 
     for c in channels:
-        if c not in all_channels:
-            raise ValueError(f"Channel `{c}` is not in `{all_channels}`.")
+        _assert_in(c, name="channel", collection=all_channels)
 
     return list(channels)
 
@@ -367,8 +366,7 @@ class FeatureMixin:
 
         props = _assert_non_empty_sequence(props, name="properties")
         for prop in props:
-            if prop not in _valid_seg_prop:
-                raise ValueError(f"Invalid property `{prop}`. Valid properties are `{_valid_seg_prop}`.")
+            _assert_in(prop, name="property", collection=_valid_seg_prop)
 
         no_intensity_props = [p for p in props if "intensity" not in p]
         intensity_props = [p for p in props if "intensity" in p]

--- a/src/squidpy/pl/_ligrec.py
+++ b/src/squidpy/pl/_ligrec.py
@@ -17,7 +17,7 @@ from scipy.cluster import hierarchy as sch
 from squidpy._constants._constants import DendrogramAxis
 from squidpy._constants._pkg_constants import Key
 from squidpy._docs import d
-from squidpy._utils import _unique_order_preserving, verbosity
+from squidpy._utils import _assert_key_exists, _unique_order_preserving, verbosity
 from squidpy.pl._utils import _dendrogram, _filter_kwargs, save_fig
 
 __all__ = ["ligrec"]
@@ -245,8 +245,7 @@ def ligrec(
             raise ValueError("Please provide `cluster_key` when supplying an `AnnData` object.")
 
         cluster_key = Key.uns.ligrec(cluster_key)
-        if cluster_key not in adata.uns_keys():
-            raise KeyError(f"Key `{cluster_key}` not found in `adata.uns`.")
+        _assert_key_exists(cluster_key, container=adata.uns, container_name="adata.uns")
         adata = adata.uns[cluster_key]
 
     if not isinstance(adata, dict):

--- a/src/squidpy/pl/_spatial_utils.py
+++ b/src/squidpy/pl/_spatial_utils.py
@@ -38,7 +38,7 @@ from skimage.util import map_array
 from squidpy._compat import add_categorical_legend
 from squidpy._constants._constants import ScatterShape
 from squidpy._constants._pkg_constants import Key
-from squidpy._utils import NDArrayA
+from squidpy._utils import NDArrayA, _assert_key_exists
 from squidpy.im._coords import CropCoords
 from squidpy.pl._color_utils import _get_palette, _maybe_set_colors
 from squidpy.pl._utils import _assert_value_in_obs
@@ -130,8 +130,7 @@ def _get_library_id(
             raise ValueError(f"Could not fetch `library_id`, check that `spatial_key: {spatial_key}` is correct.")
         return library_id
     if library_key is not None:
-        if library_key not in adata.obs:
-            raise KeyError(f"`library_key: {library_key}` not in `adata.obs`.")
+        _assert_key_exists(library_key, container=adata.obs, container_name="adata.obs")
         if library_id is None:
             library_id = adata.obs[library_key].cat.categories.tolist()
         _assert_value_in_obs(adata, key=library_key, val=library_id)
@@ -555,10 +554,7 @@ def _plot_edges(
     from networkx import Graph
     from networkx.drawing import draw_networkx_edges
 
-    if connectivity_key not in adata.obsp:
-        raise KeyError(
-            f"Unable to find `connectivity_key: {connectivity_key}` in `adata.obsp`. Please set `connectivity_key`."
-        )
+    _assert_key_exists(connectivity_key, container=adata.obsp, container_name="adata.obsp")
 
     g = Graph(adata.obsp[connectivity_key])
     if not len(g.edges):

--- a/src/squidpy/pl/_utils.py
+++ b/src/squidpy/pl/_utils.py
@@ -38,7 +38,7 @@ from skimage.color import rgb2gray
 
 from squidpy._constants._pkg_constants import Key
 from squidpy._docs import d
-from squidpy._utils import NDArrayA
+from squidpy._utils import NDArrayA, _assert_in, _assert_key_exists
 from squidpy.gr._utils import _assert_categorical_obs
 
 Vector_name_t = tuple[pd.Series | NDArrayA | None, str | None]
@@ -310,8 +310,7 @@ class ALayer:
 
     @layer.setter
     def layer(self, layer: str | None = None) -> None:
-        if layer not in (None,) + tuple(self.adata.layers.keys()):
-            raise KeyError(f"Invalid layer `{layer}`. Valid options are `{[None] + sorted(self.adata.layers.keys())}`.")
+        _assert_in(layer, name="layer", collection=(None,) + tuple(self.adata.layers.keys()))
         self._previous_layer = layer
         # handle in raw setter
         self.raw = False
@@ -654,8 +653,7 @@ def sanitize_anndata(adata: AnnData) -> None:
 
 
 def _assert_value_in_obs(adata: AnnData, key: str, val: Sequence[Any] | Any) -> None:
-    if key not in adata.obs:
-        raise KeyError(f"Key `{key}` not found in `adata.obs`.")
+    _assert_key_exists(key, container=adata.obs, container_name="adata.obs")
     if not isinstance(val, list):
         val = [val]
     val = set(val) - set(adata.obs[key].unique())

--- a/src/squidpy/tl/_sliding_window.py
+++ b/src/squidpy/tl/_sliding_window.py
@@ -9,6 +9,7 @@ from scanpy import logging as logg
 from spatialdata import SpatialData
 
 from squidpy._docs import d
+from squidpy._utils import _assert_key_exists
 from squidpy.gr._utils import _save_data
 
 __all__ = ["sliding_window"]
@@ -89,8 +90,8 @@ def sliding_window(
     if window_size <= 0:
         raise ValueError("Window size must be larger than 0.")
 
-    if library_key is not None and library_key not in adata.obs:
-        raise ValueError(f"Library key '{library_key}' not found in adata.obs")
+    if library_key is not None:
+        _assert_key_exists(library_key, container=adata.obs, container_name="adata.obs")
 
     libraries = [None] if library_key is None else adata.obs[library_key].unique()
 

--- a/src/squidpy/tl/_var_by_distance.py
+++ b/src/squidpy/tl/_var_by_distance.py
@@ -14,7 +14,7 @@ from sklearn.neighbors import KDTree
 from sklearn.preprocessing import MinMaxScaler
 
 from squidpy._docs import d
-from squidpy._utils import NDArrayA
+from squidpy._utils import NDArrayA, _assert_in
 from squidpy.gr._utils import _save_data
 
 __all__ = ["var_by_distance"]
@@ -83,8 +83,7 @@ def var_by_distance(
             if isinstance(library_id, str):
                 library_id = [library_id]
             for x in library_id:
-                if x not in adata.obs[library_key].unique():
-                    raise ValueError(f"library id {x} not in {library_key}")
+                _assert_in(x, name="library_id", collection=adata.obs[library_key].unique())
             batch = [slide for slide in library_id if slide in adata.obs[library_key].unique()]
         else:
             batch = adata.obs[library_key].unique().tolist()

--- a/tests/graph/test_ligrec.py
+++ b/tests/graph/test_ligrec.py
@@ -74,18 +74,18 @@ class TestInvalidBehavior:
             ligrec(adata, _CK, interactions=42)
 
     def test_invalid_interactions_dict(self, adata: AnnData):
-        with pytest.raises(KeyError, match=r"Column .* is not in `interactions`."):
+        with pytest.raises(KeyError, match=r"not found in `interactions.columns`"):
             ligrec(adata, _CK, interactions={"foo": ["foo"], "target": ["bar"]})
-        with pytest.raises(KeyError, match=r"Column .* is not in `interactions`."):
+        with pytest.raises(KeyError, match=r"not found in `interactions.columns`"):
             ligrec(adata, _CK, interactions={"source": ["foo"], "bar": ["bar"]})
 
     def test_invalid_interactions_dataframe(self, adata: AnnData, interactions: Interactions_t):
         df = pd.DataFrame(interactions, columns=["foo", "target"])
-        with pytest.raises(KeyError, match=r"Column .* is not in `interactions`."):
+        with pytest.raises(KeyError, match=r"not found in `interactions.columns`"):
             ligrec(adata, _CK, interactions=df)
 
         df = pd.DataFrame(interactions, columns=["source", "bar"])
-        with pytest.raises(KeyError, match=r"Column .* is not in `interactions`."):
+        with pytest.raises(KeyError, match=r"not found in `interactions.columns`"):
             ligrec(adata, _CK, interactions=df)
 
     def test_interactions_invalid_sequence(self, adata: AnnData, interactions: Interactions_t):

--- a/tests/image/test_features.py
+++ b/tests/image/test_features.py
@@ -20,11 +20,11 @@ class TestFeatureMixin:
             cont.features_summary("image")
 
     def test_invalid_layer(self, small_cont: ImageContainer):
-        with pytest.raises(KeyError, match=r"Image layer `foobar` not found in"):
+        with pytest.raises(KeyError, match=r"not found in `image layers`"):
             small_cont.features_summary("foobar")
 
     def test_invalid_channels(self, small_cont: ImageContainer):
-        with pytest.raises(ValueError, match=r"Channel `-1` is not in"):
+        with pytest.raises(ValueError, match=r"Expected `channel` to be one of"):
             small_cont.features_summary("image", channels=-1)
 
     @pytest.mark.parametrize("quantiles", [(), (0.5,), (0.1, 0.9)])
@@ -91,7 +91,7 @@ class TestFeatureMixin:
                 assert any(f"dist-{d}" in h for h in haystack), haystack
 
     def test_segmentation_invalid_props(self, small_cont: ImageContainer):
-        with pytest.raises(ValueError, match=r"Invalid property `foobar`. Valid properties are"):
+        with pytest.raises(ValueError, match=r"Expected `property` to be one of"):
             small_cont.features_segmentation("image", feature_name="foo", props=["foobar"])
 
     def test_segmentation_label(self, small_cont_seg: ImageContainer):
@@ -167,7 +167,7 @@ class TestFeatureMixin:
 
 class TestHighLevel:
     def test_invalid_layer(self, adata: AnnData, cont: ImageContainer):
-        with pytest.raises(KeyError, match=r"Image layer `foo` not found"):
+        with pytest.raises(KeyError, match=r"not found in `image layers`"):
             calculate_image_features(adata, cont, layer="foo")
 
     def test_invalid_feature(self, adata: AnnData, cont: ImageContainer):

--- a/tests/image/test_processing.py
+++ b/tests/image/test_processing.py
@@ -13,7 +13,7 @@ from squidpy.im import ImageContainer, process
 
 class TestProcess:
     def test_invalid_layer(self, small_cont: ImageContainer):
-        with pytest.raises(KeyError, match=r"Image layer `foobar` not found in"):
+        with pytest.raises(KeyError, match=r"not found in `image layers`"):
             process(small_cont, layer="foobar")
 
     @pytest.mark.parametrize("dy", [25, 0.3, None])

--- a/tests/image/test_segmentation.py
+++ b/tests/image/test_segmentation.py
@@ -82,7 +82,7 @@ class TestWatershed:
 
 class TestHighLevel:
     def test_invalid_layer(self, small_cont: ImageContainer):
-        with pytest.raises(KeyError, match=r"Image layer `foobar` not found in"):
+        with pytest.raises(KeyError, match=r"not found in `image layers`"):
             segment(small_cont, layer="foobar")
 
     @pytest.mark.parametrize("method", ["watershed", dummy_segment])

--- a/tests/plotting/test_graph.py
+++ b/tests/plotting/test_graph.py
@@ -128,7 +128,7 @@ class TestLigrec(PlotTester, metaclass=PlotTesterMeta):
             pl.ligrec(42)
 
     def test_invalid_key(self, adata: AnnData):
-        with pytest.raises(KeyError, match=r"Key `foobar_ligrec` not found in `adata.uns`."):
+        with pytest.raises(KeyError, match=r"not found in `adata.uns`"):
             pl.ligrec(adata, cluster_key="foobar")
 
     def test_valid_key_invalid_object(self, adata: AnnData):


### PR DESCRIPTION
## Description

Add two reusable validation functions (`_assert_in` and `_assert_key_exists`) to `squidpy._utils` and replace manual `if x not in y: raise ValueError/KeyError(...)` patterns across the codebase.

**New validators:**
- `_assert_in(value, *, name, collection)` — checks value membership in valid options, raises `ValueError`
- `_assert_key_exists(key, *, container, container_name)` — checks key existence in a container, raises `KeyError` with available keys listed

**Changes across 14 source files:**
- `gr/`: `_niche.py`, `_sepal.py`, `_ppatterns.py`, `_ligrec.py`
- `pl/`: `_utils.py`, `_ligrec.py`, `_spatial_utils.py`
- `im/`: `_container.py`, `_feature_mixin.py`
- `tl/`: `_sliding_window.py`, `_var_by_distance.py`
- `datasets/`: `_registry.py`
- `experimental/im/`: `_make_tiles.py`

Net result: **-28 lines** (removed duplicated validation logic), consistent error messages, and semantically clearer validation intent.

## How has this been tested?

- All existing tests pass (`pytest tests/graph/ tests/tools/ tests/image/ tests/plotting/` — 704 passed)
- Updated 5 test files to match new standardized error message format
- `ruff check` and `ruff format` pass on all modified files

## Closes

Closes #1137