### PR TITLE
cache hed scores in qc_metrics

### DIFF
--- a/src/squidpy/experimental/im/_intensity_metrics.py
+++ b/src/squidpy/experimental/im/_intensity_metrics.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import threading
-
 import numpy as np
 
 # --- Intensity metrics (grayscale input) ---
@@ -53,52 +51,51 @@ def rgb_to_hed(block_rgb: np.ndarray) -> np.ndarray:
     return rgb2hed(rgb_clipped)
 
 
-# Thread-local 1-entry cache: avoids re-computing HED deconvolution when
-# multiple HED metrics are called sequentially on the same dask block.
-# Uses threading.local so each dask worker thread gets its own cache,
-# and ctypes.data (the buffer's memory address) as the key so it remains
-# valid and unique while the array is alive.
-_hed_local = threading.local()
+def hed_metrics(block: np.ndarray) -> np.ndarray:
+    """Return all HED-derived metrics for one RGB tile."""
+    hed = rgb_to_hed(block)
+    h = hed[..., 0]
+    e = hed[..., 1]
 
-
-def _rgb_to_hed_cached(block_rgb: np.ndarray) -> np.ndarray:
-    """Cached wrapper around ``_rgb_to_hed``."""
-    key = block_rgb.ctypes.data
-    cache = getattr(_hed_local, "cache", None)
-    if cache is not None and cache[0] == key:
-        return cache[1]
-    result = rgb_to_hed(block_rgb)
-    _hed_local.cache = (key, result)
-    return result
+    return np.array(
+        [[[
+            float(h.mean()),
+            float(h.std()),
+            float(e.mean()),
+            float(e.std()),
+            float(np.abs(h).mean() / (np.abs(e).mean() + 1e-10)),
+        ]]],
+        dtype=np.float32,
+    )
 
 
 def hematoxylin_mean(block: np.ndarray) -> np.ndarray:
     """Mean hematoxylin channel intensity."""
-    hed = _rgb_to_hed_cached(block)
+    hed = rgb_to_hed(block)
     return np.array([[float(hed[..., 0].mean())]], dtype=np.float32)
 
 
 def hematoxylin_std(block: np.ndarray) -> np.ndarray:
     """Std of hematoxylin channel intensity."""
-    hed = _rgb_to_hed_cached(block)
+    hed = rgb_to_hed(block)
     return np.array([[float(hed[..., 0].std())]], dtype=np.float32)
 
 
 def eosin_mean(block: np.ndarray) -> np.ndarray:
     """Mean eosin channel intensity."""
-    hed = _rgb_to_hed_cached(block)
+    hed = rgb_to_hed(block)
     return np.array([[float(hed[..., 1].mean())]], dtype=np.float32)
 
 
 def eosin_std(block: np.ndarray) -> np.ndarray:
     """Std of eosin channel intensity."""
-    hed = _rgb_to_hed_cached(block)
+    hed = rgb_to_hed(block)
     return np.array([[float(hed[..., 1].std())]], dtype=np.float32)
 
 
 def he_ratio(block: np.ndarray) -> np.ndarray:
     """Ratio of hematoxylin to eosin mean intensity."""
-    hed = _rgb_to_hed_cached(block)
+    hed = rgb_to_hed(block)
     h_mean = float(np.abs(hed[..., 0]).mean())
     e_mean = float(np.abs(hed[..., 1]).mean())
     ratio = h_mean / (e_mean + 1e-10)

--- a/src/squidpy/experimental/im/_intensity_metrics.py
+++ b/src/squidpy/experimental/im/_intensity_metrics.py
@@ -58,13 +58,17 @@ def hed_metrics(block: np.ndarray) -> np.ndarray:
     e = hed[..., 1]
 
     return np.array(
-        [[[
-            float(h.mean()),
-            float(h.std()),
-            float(e.mean()),
-            float(e.std()),
-            float(np.abs(h).mean() / (np.abs(e).mean() + 1e-10)),
-        ]]],
+        [
+            [
+                [
+                    float(h.mean()),
+                    float(h.std()),
+                    float(e.mean()),
+                    float(e.std()),
+                    float(np.abs(h).mean() / (np.abs(e).mean() + 1e-10)),
+                ]
+            ]
+        ],
         dtype=np.float32,
     )
 

--- a/src/squidpy/experimental/im/_qc_image.py
+++ b/src/squidpy/experimental/im/_qc_image.py
@@ -15,6 +15,7 @@ from spatialdata._logging import logger
 from spatialdata.models import TableModel
 
 from squidpy._utils import _ensure_dim_order
+from squidpy.experimental.im._intensity_metrics import hed_metrics
 from squidpy.experimental.im._qc_metrics import _HNE_METRICS, InputKind, QCMetric, get_metric_info
 from squidpy.experimental.im._utils import (
     TileGrid,
@@ -185,7 +186,30 @@ def qc_image(
 
     # Build all dask graphs lazily
     delayed_scores: dict[str, da.Array] = {}
+    hed_metric_indices = {
+        QCMetric.HEMATOXYLIN_MEAN: 0,
+        QCMetric.HEMATOXYLIN_STD: 1,
+        QCMetric.EOSIN_MEAN: 2,
+        QCMetric.EOSIN_STD: 3,
+        QCMetric.HE_RATIO: 4,
+    }
+    hed_scores: da.Array | None = None
+
     for m in metrics:
+        if m in hed_metric_indices:
+            if hed_scores is None:
+                hed_scores = da.map_blocks(
+                    hed_metrics,
+                    prepared_inputs[InputKind.RGB],
+                    dtype=np.float32,
+                    chunks=out_chunks + ((5,),),
+                    drop_axis=2,
+                    new_axis=2,
+                )
+            delayed_scores[m.value] = hed_scores[..., hed_metric_indices[m]]
+            logger.info(f"- Calculating metric: '{m.value}'")
+            continue
+
         kind, metric_func = get_metric_info(m)
         source = prepared_inputs[kind]
 


### PR DESCRIPTION
No need for file and thread level caching this way. These functions arent used anywhere else so it's better if they stay pure and the caching is done by the callers and not done in a hacky way.