### PR TITLE
Add derive_mpp_from_shapes utility

### DIFF
--- a/src/squidpy/experimental/__init__.py
+++ b/src/squidpy/experimental/__init__.py
@@ -6,6 +6,6 @@ These features may change or be removed in future releases.
 
 from __future__ import annotations
 
-from . import im, pl
+from . import im, pl, utils
 
-__all__ = ["im", "pl"]
+__all__ = ["im", "pl", "utils"]

--- a/src/squidpy/experimental/utils/__init__.py
+++ b/src/squidpy/experimental/utils/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from ._derive_mpp import derive_mpp_from_shapes
+
+__all__ = ["derive_mpp_from_shapes"]

--- a/src/squidpy/experimental/utils/_derive_mpp.py
+++ b/src/squidpy/experimental/utils/_derive_mpp.py
@@ -31,7 +31,11 @@ def derive_mpp_from_shapes(
     corresponding geometric quantity in the target coordinate system and dividing the physical value
     by it.
 
-    Exactly one of ``um_between_centers`` or ``um_diameter`` must be provided.
+    Exactly one of ``um_between_centers`` or ``um_diameter`` must be provided. Prefer
+    ``um_between_centers`` when the technology's canonical pitch is known: it averages over the
+    realised grid and is robust to per-spot calibration noise in the stored radius. ``um_diameter``
+    depends on a single stored scalar and can disagree by a fraction of a percent on real Visium
+    data where the radius and grid pitch are calibrated separately.
 
     The function requires the transformation between the shapes' native frame and ``coordinate_system``
     to be a similarity (uniform scale plus optional rotation and translation). Non-uniform scales,

--- a/src/squidpy/experimental/utils/_derive_mpp.py
+++ b/src/squidpy/experimental/utils/_derive_mpp.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import numpy as np
+import shapely.affinity
+import spatialdata as sd
+from scipy.spatial import cKDTree
+from spatialdata.models import ShapesModel
+from spatialdata.models._utils import get_axes_names
+from spatialdata.transformations import get_transformation
+
+from squidpy._validators import assert_key_in_sdata
+
+__all__ = ["derive_mpp_from_shapes"]
+
+_ANISOTROPY_TOL = 1e-3
+
+
+def derive_mpp_from_shapes(
+    sdata: sd.SpatialData,
+    shapes_element: str,
+    coordinate_system: str,
+    *,
+    um_between_centers: float | None = None,
+    um_diameter: float | None = None,
+) -> float:
+    """
+    Derive microns-per-pixel for a coordinate system from a shapes element with a known physical scale.
+
+    Given a shapes element (e.g. Visium spots, Visium HD bins) whose physical spacing or diameter is
+    known, this function returns the microns-per-pixel of ``coordinate_system`` by measuring the
+    corresponding geometric quantity in the target coordinate system and dividing the physical value
+    by it.
+
+    Exactly one of ``um_between_centers`` or ``um_diameter`` must be provided.
+
+    The function requires the transformation between the shapes' native frame and ``coordinate_system``
+    to be a similarity (uniform scale plus optional rotation and translation). Non-uniform scales,
+    shear, or other anisotropy raise ``ValueError``: a single scalar microns-per-pixel is not
+    well-defined in that case.
+
+    Parameters
+    ----------
+    sdata
+        SpatialData object containing the shapes element.
+    shapes_element
+        Key of the shapes element in ``sdata.shapes``.
+    coordinate_system
+        Name of the target coordinate system (pixel grid) to derive microns-per-pixel for. Must be
+        one of the coordinate systems the shapes element is registered against.
+    um_between_centers
+        Known physical center-to-center distance of neighbouring shapes, in microns. For Visium v1
+        this is 100 (hex grid); for Visium HD it equals the bin size in microns.
+    um_diameter
+        Known physical diameter of a shape, in microns. For Visium v1 this is 55. For square-bin
+        Visium HD shapes this is interpreted as the edge length and compared against
+        ``sqrt(area)`` of the transformed polygons.
+
+    Returns
+    -------
+    float
+        Microns per pixel of ``coordinate_system``.
+
+    Raises
+    ------
+    ValueError
+        If neither or both of ``um_between_centers`` / ``um_diameter`` are given; if
+        ``coordinate_system`` is not registered for the element; if shapes are 3D or contain
+        ``MultiPolygon`` geometries; if ``um_between_centers`` is given with only one shape; or
+        if the transformation to ``coordinate_system`` is not a similarity.
+    """
+    if (um_between_centers is None) == (um_diameter is None):
+        raise ValueError("Provide exactly one of `um_between_centers` or `um_diameter`.")
+
+    assert_key_in_sdata(sdata, shapes_element, attr="shapes")
+    gdf = sdata.shapes[shapes_element]
+    ShapesModel().validate(gdf)
+
+    axes = get_axes_names(gdf)
+    if "z" in axes:
+        raise ValueError(f"Shapes element '{shapes_element}' is 3D (axes={axes}); only 2D shapes are supported.")
+
+    geom_types = set(gdf.geometry.geom_type.unique())
+    if "MultiPolygon" in geom_types:
+        raise ValueError(
+            f"Shapes element '{shapes_element}' contains MultiPolygon geometries; only Point and Polygon are supported."
+        )
+
+    all_transforms = get_transformation(gdf, get_all=True)
+    if coordinate_system not in all_transforms:
+        raise ValueError(
+            f"Coordinate system '{coordinate_system}' is not registered for shapes element "
+            f"'{shapes_element}'. Available: {sorted(all_transforms)}."
+        )
+    transform = all_transforms[coordinate_system]
+
+    affine = np.asarray(transform.to_affine_matrix(("x", "y"), ("x", "y")))
+    A = affine[:2, :2]
+    t = affine[:2, 2]
+
+    sv = np.linalg.svd(A, compute_uv=False)
+    s1, s2 = float(sv[0]), float(sv[1])
+    if abs(s1 - s2) / max(s1, s2) > _ANISOTROPY_TOL:
+        if um_between_centers is not None:
+            mpp1, mpp2 = um_between_centers / s1, um_between_centers / s2
+        else:
+            mpp1, mpp2 = um_diameter / s1, um_diameter / s2  # type: ignore[operator]
+        raise ValueError(
+            f"Transformation from shapes '{shapes_element}' to coordinate system "
+            f"'{coordinate_system}' is anisotropic (singular values {s1:.6g}, {s2:.6g}). "
+            f"A single scalar microns-per-pixel is not well-defined; per-axis values would be "
+            f"{mpp1:.6g} and {mpp2:.6g}."
+        )
+    scale = float(np.sqrt(abs(np.linalg.det(A))))
+
+    if um_between_centers is not None:
+        return _mpp_from_pitch(gdf, A, t, um_between_centers)
+    return _mpp_from_diameter(gdf, geom_types, scale, A, t, um_diameter)  # type: ignore[arg-type]
+
+
+def _mpp_from_pitch(gdf, A, t, um_between_centers: float) -> float:
+    if len(gdf) < 2:
+        raise ValueError("Pitch is undefined for a single shape; pass `um_diameter` instead.")
+    xy_native = np.column_stack([gdf.geometry.centroid.x.to_numpy(), gdf.geometry.centroid.y.to_numpy()])
+    xy_target = xy_native @ A.T + t
+    tree = cKDTree(xy_target)
+    nn_dist = tree.query(xy_target, k=2)[0][:, 1]
+    pitch_px = float(np.median(nn_dist))
+    return um_between_centers / pitch_px
+
+
+def _mpp_from_diameter(
+    gdf,
+    geom_types: set[str],
+    scale: float,
+    A: np.ndarray,
+    t: np.ndarray,
+    um_diameter: float,
+) -> float:
+    if geom_types == {"Point"}:
+        if "radius" not in gdf.columns:
+            raise ValueError("Point shapes element is missing the 'radius' column required for diameter-based mpp.")
+        diam_native = float(np.median(2.0 * gdf["radius"].to_numpy()))
+        diam_target = diam_native * scale
+    elif geom_types <= {"Polygon"}:
+        shapely_affine = [A[0, 0], A[0, 1], A[1, 0], A[1, 1], t[0], t[1]]
+        transformed = gdf.geometry.apply(lambda g: shapely.affinity.affine_transform(g, shapely_affine))
+        diam_target = float(np.sqrt(np.median(transformed.area.to_numpy())))
+    else:
+        raise ValueError(f"Unsupported geometry types {sorted(geom_types)}; expected Point or Polygon.")
+    return um_diameter / diam_target

--- a/src/squidpy/experimental/utils/_derive_mpp.py
+++ b/src/squidpy/experimental/utils/_derive_mpp.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+import geopandas as gpd
 import numpy as np
-import shapely.affinity
 import spatialdata as sd
 from scipy.spatial import cKDTree
-from spatialdata.models import ShapesModel
-from spatialdata.models._utils import get_axes_names
+from spatialdata.models import get_axes_names
 from spatialdata.transformations import get_transformation
 
 from squidpy._validators import assert_key_in_sdata
@@ -13,6 +12,7 @@ from squidpy._validators import assert_key_in_sdata
 __all__ = ["derive_mpp_from_shapes"]
 
 _ANISOTROPY_TOL = 1e-3
+_PITCH_MAX_SAMPLES = 5000
 
 
 def derive_mpp_from_shapes(
@@ -52,8 +52,8 @@ def derive_mpp_from_shapes(
         this is 100 (hex grid); for Visium HD it equals the bin size in microns.
     um_diameter
         Known physical diameter of a shape, in microns. For Visium v1 this is 55. For square-bin
-        Visium HD shapes this is interpreted as the edge length and compared against
-        ``sqrt(area)`` of the transformed polygons.
+        Visium HD shapes this is interpreted as the edge length and equated with
+        ``sqrt(median(area))`` of the transformed polygons.
 
     Returns
     -------
@@ -73,17 +73,10 @@ def derive_mpp_from_shapes(
 
     assert_key_in_sdata(sdata, shapes_element, attr="shapes")
     gdf = sdata.shapes[shapes_element]
-    ShapesModel().validate(gdf)
 
     axes = get_axes_names(gdf)
     if "z" in axes:
         raise ValueError(f"Shapes element '{shapes_element}' is 3D (axes={axes}); only 2D shapes are supported.")
-
-    geom_types = set(gdf.geometry.geom_type.unique())
-    if "MultiPolygon" in geom_types:
-        raise ValueError(
-            f"Shapes element '{shapes_element}' contains MultiPolygon geometries; only Point and Polygon are supported."
-        )
 
     all_transforms = get_transformation(gdf, get_all=True)
     if coordinate_system not in all_transforms:
@@ -91,60 +84,59 @@ def derive_mpp_from_shapes(
             f"Coordinate system '{coordinate_system}' is not registered for shapes element "
             f"'{shapes_element}'. Available: {sorted(all_transforms)}."
         )
-    transform = all_transforms[coordinate_system]
 
-    affine = np.asarray(transform.to_affine_matrix(("x", "y"), ("x", "y")))
+    geom_types = set(gdf.geometry.geom_type.unique())
+    if "MultiPolygon" in geom_types:
+        raise ValueError(
+            f"Shapes element '{shapes_element}' contains MultiPolygon geometries; only Point and Polygon are supported."
+        )
+
+    affine = np.asarray(all_transforms[coordinate_system].to_affine_matrix(("x", "y"), ("x", "y")))
     A = affine[:2, :2]
     t = affine[:2, 2]
 
     sv = np.linalg.svd(A, compute_uv=False)
     s1, s2 = float(sv[0]), float(sv[1])
     if abs(s1 - s2) / max(s1, s2) > _ANISOTROPY_TOL:
-        if um_between_centers is not None:
-            mpp1, mpp2 = um_between_centers / s1, um_between_centers / s2
-        else:
-            mpp1, mpp2 = um_diameter / s1, um_diameter / s2  # type: ignore[operator]
+        physical = um_between_centers if um_between_centers is not None else um_diameter
         raise ValueError(
             f"Transformation from shapes '{shapes_element}' to coordinate system "
             f"'{coordinate_system}' is anisotropic (singular values {s1:.6g}, {s2:.6g}). "
             f"A single scalar microns-per-pixel is not well-defined; per-axis values would be "
-            f"{mpp1:.6g} and {mpp2:.6g}."
+            f"{physical / s1:.6g} and {physical / s2:.6g}."
         )
-    scale = float(np.sqrt(abs(np.linalg.det(A))))
 
     if um_between_centers is not None:
         return _mpp_from_pitch(gdf, A, t, um_between_centers)
-    return _mpp_from_diameter(gdf, geom_types, scale, A, t, um_diameter)  # type: ignore[arg-type]
+    assert um_diameter is not None  # guaranteed by the XOR check above
+    return _mpp_from_diameter(gdf, A, um_diameter)
 
 
-def _mpp_from_pitch(gdf, A, t, um_between_centers: float) -> float:
-    if len(gdf) < 2:
+def _mpp_from_pitch(gdf: gpd.GeoDataFrame, A: np.ndarray, t: np.ndarray, um_between_centers: float) -> float:
+    n = len(gdf)
+    if n < 2:
         raise ValueError("Pitch is undefined for a single shape; pass `um_diameter` instead.")
-    xy_native = np.column_stack([gdf.geometry.centroid.x.to_numpy(), gdf.geometry.centroid.y.to_numpy()])
+    centroids = gdf.geometry.centroid
+    xy_native = np.column_stack([centroids.x.to_numpy(), centroids.y.to_numpy()])
+    if n > _PITCH_MAX_SAMPLES:
+        rng = np.random.default_rng(0)
+        xy_native = xy_native[rng.choice(n, size=_PITCH_MAX_SAMPLES, replace=False)]
     xy_target = xy_native @ A.T + t
-    tree = cKDTree(xy_target)
-    nn_dist = tree.query(xy_target, k=2)[0][:, 1]
-    pitch_px = float(np.median(nn_dist))
-    return um_between_centers / pitch_px
+    nn_dist = cKDTree(xy_target).query(xy_target, k=2)[0][:, 1]
+    return um_between_centers / float(np.median(nn_dist))
 
 
-def _mpp_from_diameter(
-    gdf,
-    geom_types: set[str],
-    scale: float,
-    A: np.ndarray,
-    t: np.ndarray,
-    um_diameter: float,
-) -> float:
+def _mpp_from_diameter(gdf: gpd.GeoDataFrame, A: np.ndarray, um_diameter: float) -> float:
+    geom_types = set(gdf.geometry.geom_type.unique())
     if geom_types == {"Point"}:
         if "radius" not in gdf.columns:
             raise ValueError("Point shapes element is missing the 'radius' column required for diameter-based mpp.")
-        diam_native = float(np.median(2.0 * gdf["radius"].to_numpy()))
-        diam_target = diam_native * scale
+        scale = float(np.sqrt(abs(np.linalg.det(A))))
+        diam_target = float(np.median(2.0 * gdf["radius"].to_numpy())) * scale
     elif geom_types <= {"Polygon"}:
-        shapely_affine = [A[0, 0], A[0, 1], A[1, 0], A[1, 1], t[0], t[1]]
-        transformed = gdf.geometry.apply(lambda g: shapely.affinity.affine_transform(g, shapely_affine))
-        diam_target = float(np.sqrt(np.median(transformed.area.to_numpy())))
+        # area transforms by |det A| under any affine, so we avoid per-geometry shapely calls
+        det = float(abs(np.linalg.det(A)))
+        diam_target = float(np.sqrt(np.median(gdf.geometry.area.to_numpy()) * det))
     else:
         raise ValueError(f"Unsupported geometry types {sorted(geom_types)}; expected Point or Polygon.")
     return um_diameter / diam_target

--- a/src/squidpy/experimental/utils/_derive_mpp.py
+++ b/src/squidpy/experimental/utils/_derive_mpp.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import geopandas as gpd
 import numpy as np
 import spatialdata as sd
@@ -13,29 +15,40 @@ __all__ = ["derive_mpp_from_shapes"]
 
 _ANISOTROPY_TOL = 1e-3
 _PITCH_MAX_SAMPLES = 5000
+_SQUARENESS_SAMPLE = 10
+_SQUARENESS_TOL = 0.98
 
 
 def derive_mpp_from_shapes(
     sdata: sd.SpatialData,
-    shapes_element: str,
+    shapes_key: str,
     coordinate_system: str,
     *,
     um_between_centers: float | None = None,
     um_diameter: float | None = None,
+    um_square_edge: float | None = None,
 ) -> float:
     """
     Derive microns-per-pixel for a coordinate system from a shapes element with a known physical scale.
 
-    Given a shapes element (e.g. Visium spots, Visium HD bins) whose physical spacing or diameter is
-    known, this function returns the microns-per-pixel of ``coordinate_system`` by measuring the
-    corresponding geometric quantity in the target coordinate system and dividing the physical value
-    by it.
+    Given a shapes element (e.g. Visium spots, Visium HD bins) whose physical spacing, spot diameter,
+    or bin edge length is known, this function returns the microns-per-pixel of
+    ``coordinate_system`` by measuring the corresponding geometric quantity in the target coordinate
+    system and dividing the physical value by it.
 
-    Exactly one of ``um_between_centers`` or ``um_diameter`` must be provided. Prefer
-    ``um_between_centers`` when the technology's canonical pitch is known: it averages over the
-    realised grid and is robust to per-spot calibration noise in the stored radius. ``um_diameter``
-    depends on a single stored scalar and can disagree by a fraction of a percent on real Visium
-    data where the radius and grid pitch are calibrated separately.
+    Exactly one of ``um_between_centers``, ``um_diameter``, or ``um_square_edge`` must be provided.
+    Prefer ``um_between_centers`` when the technology's canonical pitch is known: it averages over
+    thousands of centroid pairs in the realised grid and is robust to per-spot calibration noise in
+    the stored radius/area. ``um_diameter`` and ``um_square_edge`` depend on a single stored scalar
+    per shape and can disagree by a fraction of a percent on real Visium data where the radius and
+    grid pitch are calibrated separately.
+
+    Each physical input is geometry-specific:
+
+    - ``um_diameter`` applies only to Point geometries (uses the ``radius`` column).
+    - ``um_square_edge`` applies only to Polygon geometries and assumes square or rectangular
+      polygons; a sample of polygons is checked for squareness and the call raises if any are not.
+    - ``um_between_centers`` works for any 2D geometry.
 
     The function requires the transformation between the shapes' native frame and ``coordinate_system``
     to be a similarity (uniform scale plus optional rotation and translation). Non-uniform scales,
@@ -46,18 +59,22 @@ def derive_mpp_from_shapes(
     ----------
     sdata
         SpatialData object containing the shapes element.
-    shapes_element
+    shapes_key
         Key of the shapes element in ``sdata.shapes``.
     coordinate_system
         Name of the target coordinate system (pixel grid) to derive microns-per-pixel for. Must be
         one of the coordinate systems the shapes element is registered against.
     um_between_centers
         Known physical center-to-center distance of neighbouring shapes, in microns. For Visium v1
-        this is 100 (hex grid); for Visium HD it equals the bin size in microns.
+        this is 100 (hex grid); for Visium HD it equals the bin size in microns. Works for any 2D
+        geometry.
     um_diameter
-        Known physical diameter of a shape, in microns. For Visium v1 this is 55. For square-bin
-        Visium HD shapes this is interpreted as the edge length and equated with
-        ``sqrt(median(area))`` of the transformed polygons.
+        Known physical diameter of a circular spot, in microns. Point geometries only (uses the
+        ``radius`` column). For Visium v1 this is 55.
+    um_square_edge
+        Known physical edge length of a square/rectangular bin, in microns. Polygon geometries only.
+        For Visium HD this equals the bin size in microns. Non-rectangular polygons (e.g. hex bins,
+        circular approximations) are rejected.
 
     Returns
     -------
@@ -67,32 +84,38 @@ def derive_mpp_from_shapes(
     Raises
     ------
     ValueError
-        If neither or both of ``um_between_centers`` / ``um_diameter`` are given; if
-        ``coordinate_system`` is not registered for the element; if shapes are 3D or contain
-        ``MultiPolygon`` geometries; if ``um_between_centers`` is given with only one shape; or
-        if the transformation to ``coordinate_system`` is not a similarity.
+        If not exactly one of the three physical inputs is given; if ``coordinate_system`` is not
+        registered for the element; if shapes are 3D or contain ``MultiPolygon`` geometries; if
+        ``um_diameter`` is paired with Polygons or ``um_square_edge`` with Points; if
+        ``um_square_edge`` is paired with non-rectangular polygons; if ``um_between_centers`` is
+        given with only one shape; or if the transformation to ``coordinate_system`` is not a
+        similarity.
     """
-    if (um_between_centers is None) == (um_diameter is None):
-        raise ValueError("Provide exactly one of `um_between_centers` or `um_diameter`.")
+    n_given = sum(x is not None for x in (um_between_centers, um_diameter, um_square_edge))
+    if n_given != 1:
+        raise ValueError("Provide exactly one of `um_between_centers`, `um_diameter`, or `um_square_edge`.")
 
-    assert_key_in_sdata(sdata, shapes_element, attr="shapes")
-    gdf = sdata.shapes[shapes_element]
+    assert_key_in_sdata(sdata, shapes_key, attr="shapes")
+    gdf = sdata.shapes[shapes_key]
+
+    if len(gdf) == 0:
+        raise ValueError(f"Shapes element '{shapes_key}' is empty; cannot derive mpp.")
 
     axes = get_axes_names(gdf)
     if "z" in axes:
-        raise ValueError(f"Shapes element '{shapes_element}' is 3D (axes={axes}); only 2D shapes are supported.")
+        raise ValueError(f"Shapes element '{shapes_key}' is 3D (axes={axes}); only 2D shapes are supported.")
 
     all_transforms = get_transformation(gdf, get_all=True)
     if coordinate_system not in all_transforms:
         raise ValueError(
             f"Coordinate system '{coordinate_system}' is not registered for shapes element "
-            f"'{shapes_element}'. Available: {sorted(all_transforms)}."
+            f"'{shapes_key}'. Available: {sorted(all_transforms)}."
         )
 
     geom_types = set(gdf.geometry.geom_type.unique())
     if "MultiPolygon" in geom_types:
         raise ValueError(
-            f"Shapes element '{shapes_element}' contains MultiPolygon geometries; only Point and Polygon are supported."
+            f"Shapes element '{shapes_key}' contains MultiPolygon geometries; only Point and Polygon are supported."
         )
 
     affine = np.asarray(all_transforms[coordinate_system].to_affine_matrix(("x", "y"), ("x", "y")))
@@ -102,9 +125,9 @@ def derive_mpp_from_shapes(
     sv = np.linalg.svd(A, compute_uv=False)
     s1, s2 = float(sv[0]), float(sv[1])
     if abs(s1 - s2) / max(s1, s2) > _ANISOTROPY_TOL:
-        physical = um_between_centers if um_between_centers is not None else um_diameter
+        physical = next(x for x in (um_between_centers, um_diameter, um_square_edge) if x is not None)
         raise ValueError(
-            f"Transformation from shapes '{shapes_element}' to coordinate system "
+            f"Transformation from shapes '{shapes_key}' to coordinate system "
             f"'{coordinate_system}' is anisotropic (singular values {s1:.6g}, {s2:.6g}). "
             f"A single scalar microns-per-pixel is not well-defined; per-axis values would be "
             f"{physical / s1:.6g} and {physical / s2:.6g}."
@@ -112,35 +135,66 @@ def derive_mpp_from_shapes(
 
     if um_between_centers is not None:
         return _mpp_from_pitch(gdf, A, t, um_between_centers)
-    assert um_diameter is not None  # guaranteed by the XOR check above
-    return _mpp_from_diameter(gdf, A, um_diameter)
+    if um_diameter is not None:
+        if geom_types != {"Point"}:
+            raise ValueError(
+                f"`um_diameter` requires Point geometries; got {sorted(geom_types)}. "
+                "For square/rectangular polygons use `um_square_edge`."
+            )
+        return _mpp_from_diameter(gdf, A, um_diameter)
+    assert um_square_edge is not None
+    if geom_types != {"Polygon"}:
+        raise ValueError(
+            f"`um_square_edge` requires Polygon geometries; got {sorted(geom_types)}. "
+            "For circular Point spots use `um_diameter`."
+        )
+    return _mpp_from_square_edge(gdf, A, um_square_edge)
 
 
 def _mpp_from_pitch(gdf: gpd.GeoDataFrame, A: np.ndarray, t: np.ndarray, um_between_centers: float) -> float:
     n = len(gdf)
     if n < 2:
-        raise ValueError("Pitch is undefined for a single shape; pass `um_diameter` instead.")
+        raise ValueError("Pitch is undefined for a single shape; pass `um_diameter` or `um_square_edge` instead.")
     centroids = gdf.geometry.centroid
     xy_native = np.column_stack([centroids.x.to_numpy(), centroids.y.to_numpy()])
+    xy_target = xy_native @ A.T + t
+    query_xy = xy_target
     if n > _PITCH_MAX_SAMPLES:
         rng = np.random.default_rng(0)
-        xy_native = xy_native[rng.choice(n, size=_PITCH_MAX_SAMPLES, replace=False)]
-    xy_target = xy_native @ A.T + t
-    nn_dist = cKDTree(xy_target).query(xy_target, k=2)[0][:, 1]
+        query_xy = xy_target[rng.choice(n, size=_PITCH_MAX_SAMPLES, replace=False)]
+    nn_dist = cKDTree(xy_target).query(query_xy, k=2)[0][:, 1]
     return um_between_centers / float(np.median(nn_dist))
 
 
 def _mpp_from_diameter(gdf: gpd.GeoDataFrame, A: np.ndarray, um_diameter: float) -> float:
-    geom_types = set(gdf.geometry.geom_type.unique())
-    if geom_types == {"Point"}:
-        if "radius" not in gdf.columns:
-            raise ValueError("Point shapes element is missing the 'radius' column required for diameter-based mpp.")
-        scale = float(np.sqrt(abs(np.linalg.det(A))))
-        diam_target = float(np.median(2.0 * gdf["radius"].to_numpy())) * scale
-    elif geom_types <= {"Polygon"}:
-        # area transforms by |det A| under any affine, so we avoid per-geometry shapely calls
-        det = float(abs(np.linalg.det(A)))
-        diam_target = float(np.sqrt(np.median(gdf.geometry.area.to_numpy()) * det))
-    else:
-        raise ValueError(f"Unsupported geometry types {sorted(geom_types)}; expected Point or Polygon.")
+    if "radius" not in gdf.columns:
+        raise ValueError("Point shapes element is missing the 'radius' column required for diameter-based mpp.")
+    scale = float(np.sqrt(abs(np.linalg.det(A))))
+    diam_target = float(np.median(2.0 * gdf["radius"].to_numpy())) * scale
     return um_diameter / diam_target
+
+
+def _mpp_from_square_edge(gdf: gpd.GeoDataFrame, A: np.ndarray, um_square_edge: float) -> float:
+    _assert_polygons_are_square(gdf)
+    det = float(abs(np.linalg.det(A)))
+    edge_target = float(np.sqrt(np.median(gdf.geometry.area.to_numpy()) * det))
+    return um_square_edge / edge_target
+
+
+def _assert_polygons_are_square(gdf: gpd.GeoDataFrame) -> None:
+    n = len(gdf)
+    sample_size = min(_SQUARENESS_SAMPLE, n)
+    rng = np.random.default_rng(0)
+    sample = gdf.geometry.iloc[rng.choice(n, size=sample_size, replace=False)]
+    # shapely's oriented_envelope emits benign divide-by-zero RuntimeWarnings on axis-aligned
+    # rectangles; result is correct, so we silence them here only.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning, module=r"shapely\..*")
+        mrr_area = sample.minimum_rotated_rectangle().area.to_numpy()
+    ratios = sample.area.to_numpy() / mrr_area
+    if np.any(ratios < _SQUARENESS_TOL):
+        raise ValueError(
+            f"`um_square_edge` requires square/rectangular polygons; sampled {sample_size} polygons "
+            f"and found area/minimum-rotated-rectangle ratio below {_SQUARENESS_TOL} "
+            f"(min={float(ratios.min()):.4f}). For non-rectangular geometries use `um_between_centers`."
+        )

--- a/tests/experimental/test_derive_mpp.py
+++ b/tests/experimental/test_derive_mpp.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import math
+
+import geopandas as gpd
+import numpy as np
+import pytest
+from shapely.geometry import MultiPolygon, Point, Polygon
+from spatialdata import SpatialData
+from spatialdata.models import ShapesModel
+from spatialdata.transformations import Affine, Identity, Scale, Sequence, Translation, set_transformation
+
+from squidpy.experimental.utils import derive_mpp_from_shapes
+
+
+def _hex_lattice(pitch: float, n_rows: int = 6, n_cols: int = 6) -> np.ndarray:
+    dy = pitch * math.sin(math.pi / 3.0)
+    rows = []
+    for r in range(n_rows):
+        offset = (pitch / 2.0) if (r % 2) else 0.0
+        for c in range(n_cols):
+            rows.append((c * pitch + offset, r * dy))
+    return np.asarray(rows, dtype=float)
+
+
+def _square_lattice(pitch: float, n: int = 6) -> np.ndarray:
+    xs, ys = np.meshgrid(np.arange(n) * pitch, np.arange(n) * pitch)
+    return np.column_stack([xs.ravel(), ys.ravel()]).astype(float)
+
+
+def _points_shapes(centers: np.ndarray, radius: float) -> gpd.GeoDataFrame:
+    gdf = gpd.GeoDataFrame(
+        {"radius": np.full(len(centers), radius, dtype=float)},
+        geometry=[Point(x, y) for x, y in centers],
+    )
+    return ShapesModel.parse(gdf)
+
+
+def _square_polygons_shapes(centers: np.ndarray, edge: float) -> gpd.GeoDataFrame:
+    half = edge / 2.0
+    polys = [
+        Polygon([(x - half, y - half), (x + half, y - half), (x + half, y + half), (x - half, y + half)])
+        for x, y in centers
+    ]
+    gdf = gpd.GeoDataFrame(geometry=polys)
+    return ShapesModel.parse(gdf)
+
+
+def _make_sdata(gdf: gpd.GeoDataFrame, transforms: dict | None = None) -> SpatialData:
+    sdata = SpatialData(shapes={"shapes": gdf})
+    if transforms is not None:
+        for cs_name, transform in transforms.items():
+            set_transformation(sdata.shapes["shapes"], transform, to_coordinate_system=cs_name)
+    return sdata
+
+
+def _rotation_affine(angle_deg: float) -> Affine:
+    a = math.radians(angle_deg)
+    cos, sin = math.cos(a), math.sin(a)
+    m = np.array(
+        [
+            [cos, -sin, 0.0],
+            [sin, cos, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    return Affine(m, input_axes=("x", "y"), output_axes=("x", "y"))
+
+
+def test_hex_pitch_identity():
+    centers = _hex_lattice(pitch=100.0)
+    sdata = _make_sdata(_points_shapes(centers, radius=27.5))
+    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=100.0)
+    assert mpp == pytest.approx(1.0, rel=1e-9)
+
+
+def test_hex_pitch_scaled():
+    centers = _hex_lattice(pitch=100.0)
+    sdata = _make_sdata(_points_shapes(centers, radius=27.5), transforms={"global": Scale([2.0, 2.0], axes=("x", "y"))})
+    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=100.0)
+    assert mpp == pytest.approx(0.5, rel=1e-9)
+
+
+def test_square_pitch():
+    centers = _square_lattice(pitch=8.0)
+    sdata = _make_sdata(_points_shapes(centers, radius=1.0))
+    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=8.0)
+    assert mpp == pytest.approx(1.0, rel=1e-9)
+
+
+def test_diameter_points():
+    centers = _hex_lattice(pitch=100.0)
+    sdata = _make_sdata(_points_shapes(centers, radius=27.5), transforms={"global": Scale([4.0, 4.0], axes=("x", "y"))})
+    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_diameter=55.0)
+    # native diam = 55, scale=4 -> target diam = 220 px, mpp = 55/220 = 0.25
+    assert mpp == pytest.approx(0.25, rel=1e-9)
+
+
+def test_diameter_polygons():
+    centers = _square_lattice(pitch=8.0)
+    sdata = _make_sdata(_square_polygons_shapes(centers, edge=8.0))
+    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_diameter=8.0)
+    # native edge = 8 px under identity; sqrt(area)=8 -> mpp = 1
+    assert mpp == pytest.approx(1.0, rel=1e-9)
+
+
+def test_coordinate_system_selection():
+    centers = _square_lattice(pitch=8.0)
+    sdata = _make_sdata(
+        _points_shapes(centers, radius=1.0),
+        transforms={"native": Identity(), "downscaled": Scale([0.5, 0.5], axes=("x", "y"))},
+    )
+    mpp_native = derive_mpp_from_shapes(sdata, "shapes", "native", um_between_centers=8.0)
+    mpp_down = derive_mpp_from_shapes(sdata, "shapes", "downscaled", um_between_centers=8.0)
+    assert mpp_native == pytest.approx(1.0, rel=1e-9)
+    assert mpp_down == pytest.approx(2.0, rel=1e-9)
+    assert mpp_down / mpp_native == pytest.approx(2.0, rel=1e-9)
+
+
+def test_anisotropy_rejected():
+    centers = _square_lattice(pitch=8.0)
+    sdata = _make_sdata(_points_shapes(centers, radius=1.0), transforms={"global": Scale([2.0, 4.0], axes=("x", "y"))})
+    with pytest.raises(ValueError, match=r"anisotropic"):
+        derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=8.0)
+
+
+def test_rotation_preserved():
+    centers = _hex_lattice(pitch=100.0)
+    sdata = _make_sdata(
+        _points_shapes(centers, radius=27.5),
+        transforms={"global": Sequence([Scale([2.0, 2.0], axes=("x", "y")), _rotation_affine(30.0)])},
+    )
+    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=100.0)
+    assert mpp == pytest.approx(0.5, rel=1e-6)
+
+
+def test_sequence_translation_ignored():
+    centers = _hex_lattice(pitch=100.0)
+    sdata = _make_sdata(
+        _points_shapes(centers, radius=27.5),
+        transforms={
+            "global": Sequence([Scale([2.0, 2.0], axes=("x", "y")), Translation([10.0, -5.0], axes=("x", "y"))]),
+        },
+    )
+    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=100.0)
+    assert mpp == pytest.approx(0.5, rel=1e-9)
+
+
+def test_three_d_rejected():
+    gdf = gpd.GeoDataFrame(
+        {"radius": [1.0, 1.0]},
+        geometry=[Point(0.0, 0.0, 0.0), Point(1.0, 0.0, 0.0)],
+    )
+    gdf = ShapesModel.parse(gdf)
+    sdata = SpatialData(shapes={"shapes": gdf})
+    with pytest.raises(ValueError, match=r"3D"):
+        derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=1.0)
+
+
+def test_multipolygon_rejected():
+    p1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    p2 = Polygon([(2, 2), (3, 2), (3, 3), (2, 3)])
+    gdf = gpd.GeoDataFrame(geometry=[MultiPolygon([p1, p2])])
+    gdf = ShapesModel.parse(gdf)
+    sdata = SpatialData(shapes={"shapes": gdf})
+    with pytest.raises(ValueError, match=r"MultiPolygon"):
+        derive_mpp_from_shapes(sdata, "shapes", "global", um_diameter=1.0)
+
+
+def test_single_shape_pitch_rejected():
+    gdf = _points_shapes(np.array([[0.0, 0.0]]), radius=1.0)
+    sdata = _make_sdata(gdf)
+    with pytest.raises(ValueError, match=r"single shape"):
+        derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=100.0)
+
+
+def test_single_shape_diameter_works():
+    gdf = _points_shapes(np.array([[0.0, 0.0]]), radius=27.5)
+    sdata = _make_sdata(gdf)
+    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_diameter=55.0)
+    assert mpp == pytest.approx(1.0, rel=1e-9)
+
+
+def test_neither_arg_rejected():
+    sdata = _make_sdata(_points_shapes(_square_lattice(pitch=8.0), radius=1.0))
+    with pytest.raises(ValueError, match=r"exactly one"):
+        derive_mpp_from_shapes(sdata, "shapes", "global")
+
+
+def test_both_args_rejected():
+    sdata = _make_sdata(_points_shapes(_square_lattice(pitch=8.0), radius=1.0))
+    with pytest.raises(ValueError, match=r"exactly one"):
+        derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=8.0, um_diameter=1.0)
+
+
+def test_unknown_coordinate_system():
+    sdata = _make_sdata(
+        _points_shapes(_square_lattice(pitch=8.0), radius=1.0),
+        transforms={"native": Identity(), "downscaled": Scale([0.5, 0.5], axes=("x", "y"))},
+    )
+    with pytest.raises(ValueError, match=r"native.*downscaled|downscaled.*native"):
+        derive_mpp_from_shapes(sdata, "shapes", "missing", um_between_centers=8.0)

--- a/tests/experimental/test_derive_mpp.py
+++ b/tests/experimental/test_derive_mpp.py
@@ -92,7 +92,6 @@ def test_diameter_points():
     centers = _hex_lattice(pitch=100.0)
     sdata = _make_sdata(_points_shapes(centers, radius=27.5), transforms={"global": Scale([4.0, 4.0], axes=("x", "y"))})
     mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_diameter=55.0)
-    # native diam = 55, scale=4 -> target diam = 220 px, mpp = 55/220 = 0.25
     assert mpp == pytest.approx(0.25, rel=1e-9)
 
 
@@ -100,7 +99,6 @@ def test_diameter_polygons():
     centers = _square_lattice(pitch=8.0)
     sdata = _make_sdata(_square_polygons_shapes(centers, edge=8.0))
     mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_diameter=8.0)
-    # native edge = 8 px under identity; sqrt(area)=8 -> mpp = 1
     assert mpp == pytest.approx(1.0, rel=1e-9)
 
 

--- a/tests/experimental/test_derive_mpp.py
+++ b/tests/experimental/test_derive_mpp.py
@@ -5,7 +5,7 @@ import math
 import geopandas as gpd
 import numpy as np
 import pytest
-from shapely.geometry import MultiPolygon, Point, Polygon
+from shapely import MultiPolygon, Point, Polygon
 from spatialdata import SpatialData
 from spatialdata.models import ShapesModel
 from spatialdata.transformations import Affine, Identity, Scale, Sequence, set_transformation
@@ -46,6 +46,14 @@ def _square_polygons_shapes(centers: np.ndarray, edge: float) -> gpd.GeoDataFram
     return ShapesModel.parse(gdf)
 
 
+def _hex_polygons_shapes(centers: np.ndarray, edge: float) -> gpd.GeoDataFrame:
+    angles = np.linspace(0.0, 2 * math.pi, 7)[:-1]
+    offsets = np.column_stack([edge * np.cos(angles), edge * np.sin(angles)])
+    polys = [Polygon([(x + ox, y + oy) for ox, oy in offsets]) for x, y in centers]
+    gdf = gpd.GeoDataFrame(geometry=polys)
+    return ShapesModel.parse(gdf)
+
+
 def _make_sdata(gdf: gpd.GeoDataFrame, transforms: dict | None = None) -> SpatialData:
     sdata = SpatialData(shapes={"shapes": gdf})
     if transforms is not None:
@@ -70,6 +78,17 @@ def test_pitch(lattice, pitch, transform, expected_mpp):
     assert mpp == pytest.approx(expected_mpp, rel=1e-9)
 
 
+def test_pitch_large_grid_subsampling():
+    # 120x120 = 14_400 points: well above _PITCH_MAX_SAMPLES (5_000). The buggy
+    # tree-on-subsample implementation returns mpp ~0.35 here instead of 1.0.
+    pitch = 8.0
+    n = 120
+    centers = _square_lattice(pitch=pitch, n=n)
+    sdata = _make_sdata(_points_shapes(centers, radius=pitch / 4.0))
+    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=pitch)
+    assert mpp == pytest.approx(1.0, rel=1e-9)
+
+
 def test_diameter_points():
     centers = _hex_lattice(pitch=100.0)
     sdata = _make_sdata(_points_shapes(centers, radius=27.5), transforms={"global": Scale([4.0, 4.0], axes=("x", "y"))})
@@ -77,11 +96,30 @@ def test_diameter_points():
     assert mpp == pytest.approx(0.25, rel=1e-9)
 
 
-def test_diameter_polygons():
+def test_square_edge_polygons():
     centers = _square_lattice(pitch=8.0)
     sdata = _make_sdata(_square_polygons_shapes(centers, edge=8.0))
-    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_diameter=8.0)
+    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_square_edge=8.0)
     assert mpp == pytest.approx(1.0, rel=1e-9)
+
+
+def test_um_diameter_on_polygons_rejected():
+    sdata = _make_sdata(_square_polygons_shapes(_square_lattice(pitch=8.0), edge=8.0))
+    with pytest.raises(ValueError, match=r"um_diameter.*Point geometries"):
+        derive_mpp_from_shapes(sdata, "shapes", "global", um_diameter=8.0)
+
+
+def test_um_square_edge_on_points_rejected():
+    sdata = _make_sdata(_points_shapes(_square_lattice(pitch=8.0), radius=1.0))
+    with pytest.raises(ValueError, match=r"um_square_edge.*Polygon geometries"):
+        derive_mpp_from_shapes(sdata, "shapes", "global", um_square_edge=8.0)
+
+
+def test_um_square_edge_on_non_square_polygons_rejected():
+    centers = _square_lattice(pitch=10.0)
+    sdata = _make_sdata(_hex_polygons_shapes(centers, edge=3.0))
+    with pytest.raises(ValueError, match=r"square/rectangular polygons"):
+        derive_mpp_from_shapes(sdata, "shapes", "global", um_square_edge=3.0)
 
 
 def test_coordinate_system_selection():
@@ -149,8 +187,17 @@ def test_single_shape_diameter_works():
     assert mpp == pytest.approx(1.0, rel=1e-9)
 
 
-@pytest.mark.parametrize("kwargs", [{}, {"um_between_centers": 8.0, "um_diameter": 1.0}])
-def test_xor_args_rejected(kwargs):
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"um_between_centers": 8.0, "um_diameter": 1.0},
+        {"um_between_centers": 8.0, "um_square_edge": 8.0},
+        {"um_diameter": 1.0, "um_square_edge": 8.0},
+        {"um_between_centers": 8.0, "um_diameter": 1.0, "um_square_edge": 8.0},
+    ],
+)
+def test_mutex_args_rejected(kwargs):
     sdata = _make_sdata(_points_shapes(_square_lattice(pitch=8.0), radius=1.0))
     with pytest.raises(ValueError, match=r"exactly one"):
         derive_mpp_from_shapes(sdata, "shapes", "global", **kwargs)

--- a/tests/experimental/test_derive_mpp.py
+++ b/tests/experimental/test_derive_mpp.py
@@ -8,7 +8,7 @@ import pytest
 from shapely.geometry import MultiPolygon, Point, Polygon
 from spatialdata import SpatialData
 from spatialdata.models import ShapesModel
-from spatialdata.transformations import Affine, Identity, Scale, Sequence, Translation, set_transformation
+from spatialdata.transformations import Affine, Identity, Scale, Sequence, set_transformation
 
 from squidpy.experimental.utils import derive_mpp_from_shapes
 
@@ -54,38 +54,20 @@ def _make_sdata(gdf: gpd.GeoDataFrame, transforms: dict | None = None) -> Spatia
     return sdata
 
 
-def _rotation_affine(angle_deg: float) -> Affine:
-    a = math.radians(angle_deg)
-    cos, sin = math.cos(a), math.sin(a)
-    m = np.array(
-        [
-            [cos, -sin, 0.0],
-            [sin, cos, 0.0],
-            [0.0, 0.0, 1.0],
-        ]
-    )
-    return Affine(m, input_axes=("x", "y"), output_axes=("x", "y"))
-
-
-def test_hex_pitch_identity():
-    centers = _hex_lattice(pitch=100.0)
-    sdata = _make_sdata(_points_shapes(centers, radius=27.5))
-    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=100.0)
-    assert mpp == pytest.approx(1.0, rel=1e-9)
-
-
-def test_hex_pitch_scaled():
-    centers = _hex_lattice(pitch=100.0)
-    sdata = _make_sdata(_points_shapes(centers, radius=27.5), transforms={"global": Scale([2.0, 2.0], axes=("x", "y"))})
-    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=100.0)
-    assert mpp == pytest.approx(0.5, rel=1e-9)
-
-
-def test_square_pitch():
-    centers = _square_lattice(pitch=8.0)
-    sdata = _make_sdata(_points_shapes(centers, radius=1.0))
-    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=8.0)
-    assert mpp == pytest.approx(1.0, rel=1e-9)
+@pytest.mark.parametrize(
+    ("lattice", "pitch", "transform", "expected_mpp"),
+    [
+        (_hex_lattice, 100.0, None, 1.0),
+        (_hex_lattice, 100.0, Scale([2.0, 2.0], axes=("x", "y")), 0.5),
+        (_square_lattice, 8.0, None, 1.0),
+    ],
+)
+def test_pitch(lattice, pitch, transform, expected_mpp):
+    centers = lattice(pitch=pitch)
+    transforms = {"global": transform} if transform is not None else None
+    sdata = _make_sdata(_points_shapes(centers, radius=pitch / 4.0), transforms=transforms)
+    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=pitch)
+    assert mpp == pytest.approx(expected_mpp, rel=1e-9)
 
 
 def test_diameter_points():
@@ -103,53 +85,44 @@ def test_diameter_polygons():
 
 
 def test_coordinate_system_selection():
-    centers = _square_lattice(pitch=8.0)
     sdata = _make_sdata(
-        _points_shapes(centers, radius=1.0),
+        _points_shapes(_square_lattice(pitch=8.0), radius=1.0),
         transforms={"native": Identity(), "downscaled": Scale([0.5, 0.5], axes=("x", "y"))},
     )
     mpp_native = derive_mpp_from_shapes(sdata, "shapes", "native", um_between_centers=8.0)
     mpp_down = derive_mpp_from_shapes(sdata, "shapes", "downscaled", um_between_centers=8.0)
-    assert mpp_native == pytest.approx(1.0, rel=1e-9)
-    assert mpp_down == pytest.approx(2.0, rel=1e-9)
     assert mpp_down / mpp_native == pytest.approx(2.0, rel=1e-9)
 
 
 def test_anisotropy_rejected():
-    centers = _square_lattice(pitch=8.0)
-    sdata = _make_sdata(_points_shapes(centers, radius=1.0), transforms={"global": Scale([2.0, 4.0], axes=("x", "y"))})
+    sdata = _make_sdata(
+        _points_shapes(_square_lattice(pitch=8.0), radius=1.0),
+        transforms={"global": Scale([2.0, 4.0], axes=("x", "y"))},
+    )
     with pytest.raises(ValueError, match=r"anisotropic"):
         derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=8.0)
 
 
 def test_rotation_preserved():
-    centers = _hex_lattice(pitch=100.0)
+    angle = math.radians(30.0)
+    cos, sin = math.cos(angle), math.sin(angle)
+    rotation = Affine(
+        np.array([[cos, -sin, 0.0], [sin, cos, 0.0], [0.0, 0.0, 1.0]]),
+        input_axes=("x", "y"),
+        output_axes=("x", "y"),
+    )
     sdata = _make_sdata(
-        _points_shapes(centers, radius=27.5),
-        transforms={"global": Sequence([Scale([2.0, 2.0], axes=("x", "y")), _rotation_affine(30.0)])},
+        _points_shapes(_hex_lattice(pitch=100.0), radius=27.5),
+        transforms={"global": Sequence([Scale([2.0, 2.0], axes=("x", "y")), rotation])},
     )
     mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=100.0)
     assert mpp == pytest.approx(0.5, rel=1e-6)
 
 
-def test_sequence_translation_ignored():
-    centers = _hex_lattice(pitch=100.0)
-    sdata = _make_sdata(
-        _points_shapes(centers, radius=27.5),
-        transforms={
-            "global": Sequence([Scale([2.0, 2.0], axes=("x", "y")), Translation([10.0, -5.0], axes=("x", "y"))]),
-        },
-    )
-    mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=100.0)
-    assert mpp == pytest.approx(0.5, rel=1e-9)
-
-
 def test_three_d_rejected():
-    gdf = gpd.GeoDataFrame(
-        {"radius": [1.0, 1.0]},
-        geometry=[Point(0.0, 0.0, 0.0), Point(1.0, 0.0, 0.0)],
+    gdf = ShapesModel.parse(
+        gpd.GeoDataFrame({"radius": [1.0, 1.0]}, geometry=[Point(0.0, 0.0, 0.0), Point(1.0, 0.0, 0.0)])
     )
-    gdf = ShapesModel.parse(gdf)
     sdata = SpatialData(shapes={"shapes": gdf})
     with pytest.raises(ValueError, match=r"3D"):
         derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=1.0)
@@ -158,37 +131,29 @@ def test_three_d_rejected():
 def test_multipolygon_rejected():
     p1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
     p2 = Polygon([(2, 2), (3, 2), (3, 3), (2, 3)])
-    gdf = gpd.GeoDataFrame(geometry=[MultiPolygon([p1, p2])])
-    gdf = ShapesModel.parse(gdf)
+    gdf = ShapesModel.parse(gpd.GeoDataFrame(geometry=[MultiPolygon([p1, p2])]))
     sdata = SpatialData(shapes={"shapes": gdf})
     with pytest.raises(ValueError, match=r"MultiPolygon"):
         derive_mpp_from_shapes(sdata, "shapes", "global", um_diameter=1.0)
 
 
 def test_single_shape_pitch_rejected():
-    gdf = _points_shapes(np.array([[0.0, 0.0]]), radius=1.0)
-    sdata = _make_sdata(gdf)
+    sdata = _make_sdata(_points_shapes(np.array([[0.0, 0.0]]), radius=1.0))
     with pytest.raises(ValueError, match=r"single shape"):
         derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=100.0)
 
 
 def test_single_shape_diameter_works():
-    gdf = _points_shapes(np.array([[0.0, 0.0]]), radius=27.5)
-    sdata = _make_sdata(gdf)
+    sdata = _make_sdata(_points_shapes(np.array([[0.0, 0.0]]), radius=27.5))
     mpp = derive_mpp_from_shapes(sdata, "shapes", "global", um_diameter=55.0)
     assert mpp == pytest.approx(1.0, rel=1e-9)
 
 
-def test_neither_arg_rejected():
+@pytest.mark.parametrize("kwargs", [{}, {"um_between_centers": 8.0, "um_diameter": 1.0}])
+def test_xor_args_rejected(kwargs):
     sdata = _make_sdata(_points_shapes(_square_lattice(pitch=8.0), radius=1.0))
     with pytest.raises(ValueError, match=r"exactly one"):
-        derive_mpp_from_shapes(sdata, "shapes", "global")
-
-
-def test_both_args_rejected():
-    sdata = _make_sdata(_points_shapes(_square_lattice(pitch=8.0), radius=1.0))
-    with pytest.raises(ValueError, match=r"exactly one"):
-        derive_mpp_from_shapes(sdata, "shapes", "global", um_between_centers=8.0, um_diameter=1.0)
+        derive_mpp_from_shapes(sdata, "shapes", "global", **kwargs)
 
 
 def test_unknown_coordinate_system():


### PR DESCRIPTION
## Summary

Adds `squidpy.experimental.utils.derive_mpp_from_shapes`, a utility that computes microns-per-pixel of a target coordinate system from a shapes element plus one known physical measurement (spot pitch or spot diameter). Works for Visium, Visium HD bins, and any regular-grid shapes layout without relying on `scalefactors.json`.

- **Pitch path** (recommended): transforms centroids into the target CS, measures the median k=1 NN distance, returns `um_between_centers / pitch_px`. Subsamples to 5000 centroids on large grids (relevant at Visium HD bin counts).
- **Diameter path**: for Point shapes uses `2 * median(radius) * sqrt(|det A|)`; for Polygon shapes uses `sqrt(median(area) * |det A|)`, avoiding a per-geometry shapely call at HD scale.
- Anisotropic transformations are hard-rejected with a clear error and per-axis would-be mpps, since a single scalar mpp is not well-defined under non-uniform scale or shear.
- 3D shapes and `MultiPolygon` geometries are rejected with informative errors.