### PR TITLE
fix: remove test_raw_has_different_n_obs: raw assignment check since its part of anndata now

### DIFF
--- a/tests/graph/test_ligrec.py
+++ b/tests/graph/test_ligrec.py
@@ -35,13 +35,6 @@ class TestInvalidBehavior:
         with pytest.raises(AttributeError, match=r"No `.raw` attribute"):
             ligrec(adata, _CK, use_raw=True)
 
-    def test_raw_has_different_n_obs(self, adata: AnnData):
-        adata.raw = blobs(n_observations=adata.n_obs + 1)
-        # raise below happend with anndata < 0.9
-        # with pytest.raises(ValueError, match=rf"Expected `{adata.n_obs}` cells in `.raw`"):
-        with pytest.raises(ValueError, match=rf"Index length mismatch: {adata.n_obs} vs. {adata.n_obs + 1}"):
-            ligrec(adata, _CK)
-
     def test_invalid_cluster_key(self, adata: AnnData, interactions: Interactions_t):
         with pytest.raises(KeyError, match=r"Cluster key `foobar` not found"):
             ligrec(adata, cluster_key="foobar", interactions=interactions)


### PR DESCRIPTION
ligrec tests used to raise an error with mismatched n_obs with raw in test_raw_has_different_n_obs. Since https://github.com/scverse/anndata/pull/2351 the raw n_obs checks are inside anndata. Also our ci's use 12.11> so we can just remove this from our tests. 