### PR TITLE
Stain normalization: foundations (PR 1 of 7)

### DIFF
--- a/src/squidpy/experimental/im/_stain/__init__.py
+++ b/src/squidpy/experimental/im/_stain/__init__.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from squidpy.experimental.im._stain._constants import (
+    DEFAULT_BACKGROUND_INTENSITY,
+    DEFAULT_LUMINOSITY_THRESHOLD,
+    NEAR_ZERO_NORM,
+    RUDERMAN_LAB_TO_LMS,
+    RUDERMAN_LMS_TO_LAB,
+    RUDERMAN_LMS_TO_RGB,
+    RUDERMAN_RGB_TO_LMS,
+    RUIFROK_HE,
+    SDA_SCALE,
+    STAIN_REFERENCE_SCHEMA_VERSION,
+    StainMethod,
+)
+from squidpy.experimental.im._stain._conversion import (
+    lab_ruderman_to_rgb,
+    rgb_to_lab_ruderman,
+    rgb_to_sda,
+    sda_to_rgb,
+)
+from squidpy.experimental.im._stain._reference import StainReference
+from squidpy.experimental.im._stain._validation import (
+    StainFittingError,
+    complement_third_column,
+    reorder_to_canonical,
+    validate_stain_matrix,
+)
+
+__all__ = [
+    "DEFAULT_BACKGROUND_INTENSITY",
+    "DEFAULT_LUMINOSITY_THRESHOLD",
+    "NEAR_ZERO_NORM",
+    "RUDERMAN_LAB_TO_LMS",
+    "RUDERMAN_LMS_TO_LAB",
+    "RUDERMAN_LMS_TO_RGB",
+    "RUDERMAN_RGB_TO_LMS",
+    "RUIFROK_HE",
+    "SDA_SCALE",
+    "STAIN_REFERENCE_SCHEMA_VERSION",
+    "StainFittingError",
+    "StainMethod",
+    "StainReference",
+    "complement_third_column",
+    "lab_ruderman_to_rgb",
+    "reorder_to_canonical",
+    "rgb_to_lab_ruderman",
+    "rgb_to_sda",
+    "sda_to_rgb",
+    "validate_stain_matrix",
+]

--- a/src/squidpy/experimental/im/_stain/_constants.py
+++ b/src/squidpy/experimental/im/_stain/_constants.py
@@ -1,0 +1,84 @@
+"""Canonical stain vectors, color-space matrices, and module-wide defaults.
+
+Constants live at module scope and must not be mutated by callers.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+import numpy as np
+from skimage.color import rgb_from_hed
+
+STAIN_REFERENCE_SCHEMA_VERSION: int = 1
+
+DEFAULT_BACKGROUND_INTENSITY: np.ndarray = np.array([255.0, 255.0, 255.0], dtype=np.float64)
+DEFAULT_BACKGROUND_INTENSITY.flags.writeable = False
+
+DEFAULT_LUMINOSITY_THRESHOLD: float = 0.15
+
+NEAR_ZERO_NORM: float = 1e-8
+
+
+class StainMethod(StrEnum):
+    """Fitting methods supported by :class:`StainReference`."""
+
+    MACENKO = "macenko"
+    VAHADANE = "vahadane"
+    REINHARD = "reinhard"
+
+
+def _unit(v: np.ndarray) -> np.ndarray:
+    a = np.asarray(v, dtype=np.float64)
+    a /= np.linalg.norm(a)
+    a.flags.writeable = False
+    return a
+
+
+# Ruifrok and Johnston (2001) canonical stain vectors, unit-normalised.
+# Sourced from `skimage.color.rgb_from_hed` so the values stay consistent with
+# downstream scikit-image consumers; skimage stores them un-normalised, hence
+# the `_unit` step.
+RUIFROK_HE: dict[str, np.ndarray] = {
+    "hematoxylin": _unit(rgb_from_hed[0]),
+    "eosin": _unit(rgb_from_hed[1]),
+    "dab": _unit(rgb_from_hed[2]),
+}
+
+# HistomicsTK-compatible SDA scale: encodes optical density so that luminosity
+# thresholds taken from the literature transfer directly.
+SDA_SCALE: float = 255.0 / np.log(256.0)
+
+# Ruderman, Cronin, Chiao (1998) decorrelated colour space, as used by
+# Reinhard et al. (2001). NOT equivalent to CIE Lab and NOT interchangeable
+# with `skimage.color.rgb2lab`. Matrices are taken verbatim from the Reinhard
+# 2001 paper and reproduced by HistomicsTK.
+RUDERMAN_RGB_TO_LMS: np.ndarray = np.array(
+    [
+        [0.3811, 0.5783, 0.0402],
+        [0.1967, 0.7244, 0.0782],
+        [0.0241, 0.1288, 0.8444],
+    ],
+    dtype=np.float64,
+)
+RUDERMAN_RGB_TO_LMS.flags.writeable = False
+
+RUDERMAN_LMS_TO_RGB: np.ndarray = np.linalg.inv(RUDERMAN_RGB_TO_LMS)
+RUDERMAN_LMS_TO_RGB.flags.writeable = False
+
+# Reinhard 2001 eq. 4: a diagonal (1/sqrt(3), 1/sqrt(6), 1/sqrt(2)) scaling
+# followed by an orthogonal mixing matrix.
+_DIAG = np.diag([1.0 / np.sqrt(3.0), 1.0 / np.sqrt(6.0), 1.0 / np.sqrt(2.0)])
+_MIX = np.array(
+    [
+        [1.0, 1.0, 1.0],
+        [1.0, 1.0, -2.0],
+        [1.0, -1.0, 0.0],
+    ],
+    dtype=np.float64,
+)
+RUDERMAN_LMS_TO_LAB: np.ndarray = _DIAG @ _MIX
+RUDERMAN_LMS_TO_LAB.flags.writeable = False
+
+RUDERMAN_LAB_TO_LMS: np.ndarray = np.linalg.inv(RUDERMAN_LMS_TO_LAB)
+RUDERMAN_LAB_TO_LMS.flags.writeable = False

--- a/src/squidpy/experimental/im/_stain/_conversion.py
+++ b/src/squidpy/experimental/im/_stain/_conversion.py
@@ -1,0 +1,183 @@
+"""RGB <-> optical density (SDA) and RGB <-> Ruderman Lab conversions.
+
+All functions operate on :class:`xarray.DataArray` with a channel dimension
+named ``"c"`` of length 3. Numpy-backed and dask-backed inputs are both
+supported transparently; nothing here forces materialisation of large arrays.
+Each public function compiles down to a single :func:`xarray.apply_ufunc`
+call so that dask schedules one task per chunk regardless of how many
+elementwise and matrix steps the transform contains.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+
+from squidpy.experimental.im._stain._constants import (
+    DEFAULT_BACKGROUND_INTENSITY,
+    RUDERMAN_LAB_TO_LMS,
+    RUDERMAN_LMS_TO_LAB,
+    RUDERMAN_LMS_TO_RGB,
+    RUDERMAN_RGB_TO_LMS,
+    SDA_SCALE,
+)
+
+_CHANNEL_DIM = "c"
+
+
+def _check_channel_dim(arr: xr.DataArray) -> None:
+    if _CHANNEL_DIM not in arr.dims:
+        raise ValueError(f"Input must have a dimension named {_CHANNEL_DIM!r}; got dims {arr.dims}.")
+    if arr.sizes[_CHANNEL_DIM] != 3:
+        raise ValueError(f"Channel dimension {_CHANNEL_DIM!r} must have length 3; got {arr.sizes[_CHANNEL_DIM]}.")
+
+
+def _background_as_numpy(
+    background_intensity: xr.DataArray | np.ndarray | float | int,
+) -> np.ndarray:
+    if isinstance(background_intensity, xr.DataArray):
+        arr = np.asarray(background_intensity.values, dtype=np.float64)
+    else:
+        arr = np.asarray(background_intensity, dtype=np.float64)
+    if arr.ndim == 0:
+        arr = np.repeat(arr, 3)
+    if arr.shape != (3,):
+        raise ValueError(f"background_intensity must be scalar or shape (3,); got shape {arr.shape}.")
+    return arr
+
+
+def _working_dtype(arr: xr.DataArray) -> np.dtype:
+    # Integer/uint inputs are promoted to float32 to keep dask graphs cheap
+    # on whole-slide images; already-float inputs preserve caller dtype.
+    return arr.dtype if np.issubdtype(arr.dtype, np.floating) else np.dtype(np.float32)
+
+
+def _apply_along_channel(
+    arr: xr.DataArray,
+    kernel,
+    *,
+    out_dtype: np.dtype,
+    **kwargs,
+) -> xr.DataArray:
+    """Run a per-chunk kernel that consumes and returns the channel axis.
+
+    ``apply_ufunc`` moves the ``c`` core dim to the end of the output; we
+    transpose back to the caller's original dim order so downstream
+    consumers see a stable layout.
+    """
+    original_dims = arr.dims
+    out = xr.apply_ufunc(
+        kernel,
+        arr,
+        input_core_dims=[[_CHANNEL_DIM]],
+        output_core_dims=[[_CHANNEL_DIM]],
+        kwargs=kwargs,
+        dask="parallelized",
+        output_dtypes=[out_dtype],
+    )
+    return out.transpose(*original_dims)
+
+
+def _rgb_to_sda_kernel(x: np.ndarray, *, bg: np.ndarray, dtype: np.dtype) -> np.ndarray:
+    x = x.astype(dtype, copy=False)
+    return (-np.log((x + 1.0) / (bg + 1.0)) * SDA_SCALE).astype(dtype, copy=False)
+
+
+def _sda_to_rgb_kernel(x: np.ndarray, *, bg: np.ndarray, dtype: np.dtype) -> np.ndarray:
+    rgb = (bg + 1.0) * np.exp(-x.astype(dtype, copy=False) / SDA_SCALE) - 1.0
+    np.clip(rgb, 0.0, 255.0, out=rgb)
+    return rgb.astype(dtype, copy=False)
+
+
+def _rgb_to_lab_kernel(x: np.ndarray, *, dtype: np.dtype) -> np.ndarray:
+    x = x.astype(dtype, copy=False)
+    lms = x @ RUDERMAN_RGB_TO_LMS.T.astype(dtype, copy=False)
+    np.log(lms + 1.0, out=lms)
+    return (lms @ RUDERMAN_LMS_TO_LAB.T.astype(dtype, copy=False)).astype(dtype, copy=False)
+
+
+def _lab_to_rgb_kernel(x: np.ndarray, *, dtype: np.dtype) -> np.ndarray:
+    x = x.astype(dtype, copy=False)
+    log_lms = x @ RUDERMAN_LAB_TO_LMS.T.astype(dtype, copy=False)
+    # The +1.0 / -1.0 pair is paired with the matching offset in
+    # `_rgb_to_lab_kernel` so the round trip remains exact for valid RGB.
+    lms = np.exp(log_lms) - 1.0
+    rgb = lms @ RUDERMAN_LMS_TO_RGB.T.astype(dtype, copy=False)
+    np.clip(rgb, 0.0, 255.0, out=rgb)
+    return rgb.astype(dtype, copy=False)
+
+
+def rgb_to_sda(
+    rgb: xr.DataArray,
+    background_intensity: xr.DataArray | np.ndarray | float = DEFAULT_BACKGROUND_INTENSITY,
+) -> xr.DataArray:
+    """Convert RGB intensities to standard deviation per absorbance (SDA).
+
+    Equivalent to optical density with a per-channel background ``I_0``::
+
+        sda = -log((rgb + 1) / (I_0 + 1)) * SDA_SCALE
+
+    The matched ``+1`` terms avoid ``log(0)`` at fully saturated black
+    pixels and guarantee that pixels at the white point map exactly to
+    zero. Scaling matches the HistomicsTK convention so that luminosity
+    thresholds from the published H&E literature transfer directly.
+
+    Parameters
+    ----------
+    rgb
+        Image with a ``"c"`` dimension of length 3. May be numpy- or
+        dask-backed; the operation is purely elementwise and stays lazy.
+    background_intensity
+        Per-channel white-point ``I_0``. Scalar, shape-``(3,)`` array, or a
+        DataArray with a ``"c"`` dim of length 3.
+
+    Returns
+    -------
+    SDA-space DataArray, float dtype. Lazy if and only if ``rgb`` was lazy.
+    """
+    _check_channel_dim(rgb)
+    dtype = _working_dtype(rgb)
+    bg = _background_as_numpy(background_intensity).astype(dtype, copy=False)
+    return _apply_along_channel(rgb, _rgb_to_sda_kernel, out_dtype=dtype, bg=bg, dtype=dtype)
+
+
+def sda_to_rgb(
+    sda: xr.DataArray,
+    background_intensity: xr.DataArray | np.ndarray | float = DEFAULT_BACKGROUND_INTENSITY,
+) -> xr.DataArray:
+    """Convert SDA back to RGB intensities in ``[0, 255]``.
+
+    Inverse of :func:`rgb_to_sda`. The result is clipped to ``[0, 255]`` but
+    kept in float dtype; uint8 conversion is the caller's choice.
+    """
+    _check_channel_dim(sda)
+    dtype = _working_dtype(sda)
+    bg = _background_as_numpy(background_intensity).astype(dtype, copy=False)
+    return _apply_along_channel(sda, _sda_to_rgb_kernel, out_dtype=dtype, bg=bg, dtype=dtype)
+
+
+def rgb_to_lab_ruderman(rgb: xr.DataArray) -> xr.DataArray:
+    """Convert RGB to Ruderman et al. (1998) decorrelated Lab space.
+
+    This is the Lab variant used by Reinhard et al. (2001) for colour
+    transfer, not CIE Lab. Results differ from
+    :func:`skimage.color.rgb2lab`.
+
+    The pipeline is RGB -> LMS via :data:`RUDERMAN_RGB_TO_LMS`, then
+    ``log(LMS + 1)``, then LMS -> Lab via :data:`RUDERMAN_LMS_TO_LAB`. All
+    steps fuse into a single per-chunk numpy kernel.
+    """
+    _check_channel_dim(rgb)
+    dtype = _working_dtype(rgb)
+    return _apply_along_channel(rgb, _rgb_to_lab_kernel, out_dtype=dtype, dtype=dtype)
+
+
+def lab_ruderman_to_rgb(lab: xr.DataArray) -> xr.DataArray:
+    """Inverse of :func:`rgb_to_lab_ruderman`.
+
+    Returns RGB clipped to ``[0, 255]`` in float dtype; uint8 conversion is
+    the caller's choice.
+    """
+    _check_channel_dim(lab)
+    dtype = _working_dtype(lab)
+    return _apply_along_channel(lab, _lab_to_rgb_kernel, out_dtype=dtype, dtype=dtype)

--- a/src/squidpy/experimental/im/_stain/_reference.py
+++ b/src/squidpy/experimental/im/_stain/_reference.py
@@ -1,0 +1,226 @@
+"""Persistent reference object for a fitted stain model."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from squidpy.experimental.im._stain._constants import (
+    DEFAULT_BACKGROUND_INTENSITY,
+    STAIN_REFERENCE_SCHEMA_VERSION,
+    StainMethod,
+)
+
+_DECOMPOSITION_METHODS: frozenset[StainMethod] = frozenset({StainMethod.MACENKO, StainMethod.VAHADANE})
+_SCHEMA_TAG: str = "squidpy.stain_reference"
+_ENCODED_NDARRAY_KEYS: frozenset[str] = frozenset({"__ndarray__", "dtype", "shape"})
+
+_PERSISTED_ARRAY_FIELDS: tuple[str, ...] = (
+    "stain_matrix",
+    "max_concentrations",
+    "mu",
+    "sigma",
+    "background_intensity",
+)
+
+
+def _coerce_finite(arr: Any, *, shape: tuple[int, ...], name: str) -> np.ndarray:
+    out = np.asarray(arr, dtype=np.float64)
+    if out.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}; got {out.shape}.")
+    if not np.all(np.isfinite(out)):
+        raise ValueError(f"{name} contains non-finite values.")
+    return out
+
+
+@dataclass(frozen=True)
+class StainReference:
+    """Container for a fitted stain reference.
+
+    Holds either a stain matrix (for decomposition methods) or a pair of
+    channel statistics (for the Reinhard statistical method). Round-trips
+    through JSON via :meth:`save` and :meth:`load`. Frozen so it can be
+    passed safely across worker processes.
+
+    Parameters
+    ----------
+    method
+        Fitting method. See :class:`StainMethod`.
+    version
+        Schema version. Set automatically; bump
+        :data:`STAIN_REFERENCE_SCHEMA_VERSION` for migrations.
+    stain_matrix
+        Shape ``(3, 3)`` unit-norm matrix in canonical order
+        ``(H, E, complement)``. Required for decomposition methods.
+    max_concentrations
+        Optional shape ``(2,)`` p99 concentrations of H and E used for
+        dynamic-range matching during apply. Decomposition methods only.
+    mu
+        Shape ``(3,)`` Ruderman Lab channel means. Reinhard only.
+    sigma
+        Shape ``(3,)`` Ruderman Lab channel standard deviations. Reinhard
+        only.
+    background_intensity
+        Shape ``(3,)`` per-channel white-point estimate.
+    fit_metadata
+        Free-form dict for provenance (squidpy version, image keys, pyramid
+        level, seed, timestamp, aggregation rule).
+    cohort_members
+        Tuple of image keys aggregated into this reference. Cohort fits
+        only.
+    per_image_stats
+        Raw per-image fits keyed by image. Cohort fits only.
+    """
+
+    method: StainMethod
+    version: int = STAIN_REFERENCE_SCHEMA_VERSION
+    stain_matrix: np.ndarray | None = None
+    max_concentrations: np.ndarray | None = None
+    mu: np.ndarray | None = None
+    sigma: np.ndarray | None = None
+    background_intensity: np.ndarray = field(default_factory=lambda: DEFAULT_BACKGROUND_INTENSITY.copy())
+    fit_metadata: dict = field(default_factory=dict)
+    cohort_members: tuple[str, ...] | None = None
+    per_image_stats: dict | None = None
+
+    def __post_init__(self) -> None:
+        try:
+            method = StainMethod(self.method)
+        except ValueError as exc:
+            raise ValueError(
+                f"Unknown method {self.method!r}; expected one of {[m.value for m in StainMethod]}."
+            ) from exc
+        object.__setattr__(self, "method", method)
+
+        if method in _DECOMPOSITION_METHODS:
+            self._validate_decomposition()
+        else:
+            self._validate_reinhard()
+
+        bg = _coerce_finite(self.background_intensity, shape=(3,), name="background_intensity")
+        if np.any(bg <= 0):
+            raise ValueError("background_intensity must be strictly positive.")
+        object.__setattr__(self, "background_intensity", bg)
+
+        if self.cohort_members is not None and not isinstance(self.cohort_members, tuple):
+            object.__setattr__(self, "cohort_members", tuple(self.cohort_members))
+
+    def _validate_decomposition(self) -> None:
+        if self.stain_matrix is None:
+            raise ValueError(f"method={self.method.value!r} requires stain_matrix.")
+        if self.mu is not None or self.sigma is not None:
+            raise ValueError(f"method={self.method.value!r} forbids mu/sigma; pass them only for Reinhard.")
+        object.__setattr__(
+            self,
+            "stain_matrix",
+            _coerce_finite(self.stain_matrix, shape=(3, 3), name="stain_matrix"),
+        )
+        if self.max_concentrations is not None:
+            object.__setattr__(
+                self,
+                "max_concentrations",
+                _coerce_finite(self.max_concentrations, shape=(2,), name="max_concentrations"),
+            )
+
+    def _validate_reinhard(self) -> None:
+        if self.mu is None or self.sigma is None:
+            raise ValueError("method='reinhard' requires both mu and sigma.")
+        if self.stain_matrix is not None or self.max_concentrations is not None:
+            raise ValueError("method='reinhard' forbids stain_matrix/max_concentrations.")
+        mu = _coerce_finite(self.mu, shape=(3,), name="mu")
+        sigma = _coerce_finite(self.sigma, shape=(3,), name="sigma")
+        if np.any(sigma <= 0):
+            raise ValueError("sigma must be strictly positive.")
+        object.__setattr__(self, "mu", mu)
+        object.__setattr__(self, "sigma", sigma)
+
+    def save(self, path: str | Path) -> None:
+        """Write the reference to a JSON file."""
+        Path(path).write_text(json.dumps(_to_json(self), indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: str | Path) -> StainReference:
+        """Load a reference previously written by :meth:`save`."""
+        try:
+            payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Could not parse StainReference JSON at {path!s}: {exc}") from exc
+        return _from_json(payload)
+
+
+def _encode_ndarray(arr: np.ndarray) -> dict[str, Any]:
+    return {"__ndarray__": arr.tolist(), "dtype": str(arr.dtype), "shape": list(arr.shape)}
+
+
+def _decode_ndarray(blob: dict[str, Any]) -> np.ndarray:
+    return np.asarray(blob["__ndarray__"], dtype=np.dtype(blob["dtype"])).reshape(blob["shape"])
+
+
+def _is_encoded_ndarray(value: Any) -> bool:
+    return isinstance(value, dict) and _ENCODED_NDARRAY_KEYS.issubset(value.keys())
+
+
+def _encode(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return _encode_ndarray(value)
+    if isinstance(value, dict):
+        return {k: _encode(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_encode(v) for v in value]
+    return value
+
+
+def _decode(value: Any) -> Any:
+    if _is_encoded_ndarray(value):
+        return _decode_ndarray(value)
+    if isinstance(value, dict):
+        return {k: _decode(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_decode(v) for v in value]
+    return value
+
+
+def _to_json(ref: StainReference) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema": _SCHEMA_TAG,
+        "version": ref.version,
+        "method": ref.method.value,
+        "fit_metadata": _encode(ref.fit_metadata),
+    }
+    for name in _PERSISTED_ARRAY_FIELDS:
+        value = getattr(ref, name)
+        if value is not None:
+            payload[name] = _encode_ndarray(value)
+    if ref.cohort_members is not None:
+        payload["cohort_members"] = list(ref.cohort_members)
+    if ref.per_image_stats is not None:
+        payload["per_image_stats"] = _encode(ref.per_image_stats)
+    return payload
+
+
+def _from_json(payload: dict[str, Any]) -> StainReference:
+    if payload.get("schema") != _SCHEMA_TAG:
+        raise ValueError("File is not a squidpy stain reference (missing schema marker).")
+    version = int(payload.get("version", 1))
+    if version > STAIN_REFERENCE_SCHEMA_VERSION:
+        raise ValueError(
+            f"StainReference file version {version} is newer than this squidpy "
+            f"(supports up to {STAIN_REFERENCE_SCHEMA_VERSION}). Upgrade squidpy to load it."
+        )
+    kwargs: dict[str, Any] = {
+        "method": payload["method"],
+        "version": version,
+        "fit_metadata": _decode(payload.get("fit_metadata", {})),
+    }
+    for name in _PERSISTED_ARRAY_FIELDS:
+        if name in payload:
+            kwargs[name] = _decode_ndarray(payload[name])
+    if "cohort_members" in payload:
+        kwargs["cohort_members"] = tuple(payload["cohort_members"])
+    if "per_image_stats" in payload:
+        kwargs["per_image_stats"] = _decode(payload["per_image_stats"])
+    return StainReference(**kwargs)

--- a/src/squidpy/experimental/im/_stain/_validation.py
+++ b/src/squidpy/experimental/im/_stain/_validation.py
@@ -1,0 +1,125 @@
+"""Validation and canonicalisation helpers for fitted stain matrices."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from squidpy.experimental.im._stain._constants import NEAR_ZERO_NORM, RUIFROK_HE
+
+
+class StainFittingError(RuntimeError):
+    """Raised when a stain matrix fit is unusable.
+
+    Carries the image key (when known) so cohort-fit code can attribute the
+    failure to a specific sample rather than failing the whole batch.
+    """
+
+    def __init__(self, reason: str, *, image_key: str | None = None) -> None:
+        self.reason = reason
+        self.image_key = image_key
+        prefix = f"[{image_key}] " if image_key else ""
+        super().__init__(f"{prefix}{reason}")
+
+
+def _ensure_2d(W: np.ndarray, *, expected_cols: tuple[int, ...]) -> np.ndarray:
+    W = np.asarray(W, dtype=np.float64)
+    if W.ndim != 2 or W.shape[0] != 3 or W.shape[1] not in expected_cols:
+        cols = " or ".join(f"(3, {n})" for n in expected_cols)
+        raise ValueError(f"Stain matrix must have shape {cols}; got {W.shape}.")
+    return W
+
+
+def _normalise_columns(W: np.ndarray, *, image_key: str | None = None) -> np.ndarray:
+    norms = np.linalg.norm(W, axis=0)
+    if np.any(norms < NEAR_ZERO_NORM):
+        raise StainFittingError("Stain matrix has a near-zero column.", image_key=image_key)
+    return W / norms
+
+
+def _angle_deg(a: np.ndarray, b: np.ndarray) -> float:
+    cos = float(np.clip(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)), -1.0, 1.0))
+    return float(np.degrees(np.arccos(cos)))
+
+
+def reorder_to_canonical(
+    W: np.ndarray,
+    reference: dict[str, np.ndarray] = RUIFROK_HE,
+    *,
+    stain_order: tuple[str, str] = ("hematoxylin", "eosin"),
+) -> np.ndarray:
+    """Reorder the first two columns of ``W`` into canonical ``(H, E, ...)``.
+
+    Macenko and Vahadane both produce stain vectors in arbitrary order; this
+    aligns each column with its nearest canonical reference and flips the
+    sign so the column points the same way as the canonical vector. Returns
+    a new array of the same shape as ``W``; the third column (if present) is
+    left untouched.
+    """
+    W = _ensure_2d(W, expected_cols=(2, 3))
+    ref_vectors = [reference[name] for name in stain_order]
+
+    candidates = W[:, :2]
+    pairs: list[tuple[int, int]] = [(0, 1), (1, 0)]
+    best_pair = max(
+        pairs,
+        key=lambda p: sum(abs(float(np.dot(candidates[:, p[k]], ref_vectors[k]))) for k in range(2)),
+    )
+
+    out = W.copy()
+    for k, src in enumerate(best_pair):
+        col = candidates[:, src].copy()
+        if np.dot(col, ref_vectors[k]) < 0:
+            col = -col
+        out[:, k] = col
+    return out
+
+
+def complement_third_column(W: np.ndarray) -> np.ndarray:
+    """Append a unit-norm column orthogonal to the first two.
+
+    Given ``W`` of shape ``(3, 2)``, return a ``(3, 3)`` matrix whose third
+    column is the normalised cross product of columns 0 and 1.
+    """
+    W = _ensure_2d(W, expected_cols=(2,))
+    third = np.cross(W[:, 0], W[:, 1])
+    n = np.linalg.norm(third)
+    if n < NEAR_ZERO_NORM:
+        raise StainFittingError("First two stain vectors are collinear; cannot complement.")
+    third = third / n
+    return np.column_stack([W, third])
+
+
+def validate_stain_matrix(
+    W: np.ndarray,
+    *,
+    image_key: str | None = None,
+    reference: dict[str, np.ndarray] = RUIFROK_HE,
+    stain_order: tuple[str, str] = ("hematoxylin", "eosin"),
+    max_angle_deg: float = 45.0,
+    min_singular_value: float = 1e-3,
+) -> None:
+    """Validate a fitted ``(3, 3)`` stain matrix.
+
+    Raises :class:`StainFittingError` if any column is degenerate, the
+    matrix is rank-deficient, or the H or E column deviates from its
+    canonical reference by more than ``max_angle_deg`` degrees.
+    """
+    W = _ensure_2d(W, expected_cols=(3,))
+    W = _normalise_columns(W, image_key=image_key)
+
+    singular_values = np.linalg.svd(W, compute_uv=False)
+    if float(singular_values.min()) < min_singular_value:
+        raise StainFittingError(
+            f"Stain matrix is rank-deficient (min singular value "
+            f"{singular_values.min():.2e} < {min_singular_value:.2e}).",
+            image_key=image_key,
+        )
+
+    for k, name in enumerate(stain_order):
+        ref = reference[name]
+        angle = _angle_deg(W[:, k], ref)
+        if angle > max_angle_deg and (180.0 - angle) > max_angle_deg:
+            raise StainFittingError(
+                f"Stain column {k} ({name}) deviates from canonical by {angle:.1f} degrees (>{max_angle_deg:.1f}).",
+                image_key=image_key,
+            )

--- a/tests/experimental/test_stain_constants.py
+++ b/tests/experimental/test_stain_constants.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from squidpy.experimental.im._stain._constants import (
+    DEFAULT_BACKGROUND_INTENSITY,
+    RUDERMAN_LAB_TO_LMS,
+    RUDERMAN_LMS_TO_LAB,
+    RUDERMAN_LMS_TO_RGB,
+    RUDERMAN_RGB_TO_LMS,
+    RUIFROK_HE,
+    SDA_SCALE,
+    STAIN_REFERENCE_SCHEMA_VERSION,
+)
+
+
+class TestRuifrok:
+    @pytest.mark.parametrize("stain", ["hematoxylin", "eosin", "dab"])
+    def test_unit_norm(self, stain: str) -> None:
+        v = RUIFROK_HE[stain]
+        assert v.shape == (3,)
+        np.testing.assert_allclose(np.linalg.norm(v), 1.0, atol=1e-12)
+
+    def test_arrays_are_immutable(self) -> None:
+        with pytest.raises(ValueError):
+            RUIFROK_HE["hematoxylin"][0] = 0.0
+
+
+class TestRuderman:
+    def test_rgb_lms_round_trip(self) -> None:
+        np.testing.assert_allclose(RUDERMAN_RGB_TO_LMS @ RUDERMAN_LMS_TO_RGB, np.eye(3), atol=1e-10)
+        np.testing.assert_allclose(RUDERMAN_LMS_TO_RGB @ RUDERMAN_RGB_TO_LMS, np.eye(3), atol=1e-10)
+
+    def test_lms_lab_round_trip(self) -> None:
+        np.testing.assert_allclose(RUDERMAN_LMS_TO_LAB @ RUDERMAN_LAB_TO_LMS, np.eye(3), atol=1e-10)
+        np.testing.assert_allclose(RUDERMAN_LAB_TO_LMS @ RUDERMAN_LMS_TO_LAB, np.eye(3), atol=1e-10)
+
+
+class TestModuleDefaults:
+    def test_background_intensity(self) -> None:
+        np.testing.assert_array_equal(DEFAULT_BACKGROUND_INTENSITY, [255.0, 255.0, 255.0])
+        with pytest.raises(ValueError):
+            DEFAULT_BACKGROUND_INTENSITY[0] = 0.0
+
+    def test_sda_scale_positive(self) -> None:
+        assert SDA_SCALE > 0.0
+
+    def test_schema_version(self) -> None:
+        assert STAIN_REFERENCE_SCHEMA_VERSION == 1

--- a/tests/experimental/test_stain_conversion.py
+++ b/tests/experimental/test_stain_conversion.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+
+from squidpy.experimental.im._stain._conversion import (
+    lab_ruderman_to_rgb,
+    rgb_to_lab_ruderman,
+    rgb_to_sda,
+    sda_to_rgb,
+)
+
+
+def _rgb_dataarray(values: np.ndarray, *, chunked: bool) -> xr.DataArray:
+    if chunked:
+        data = da.from_array(values, chunks=(3, 8, 8))
+    else:
+        data = values
+    return xr.DataArray(data, dims=("c", "y", "x"))
+
+
+@pytest.fixture
+def random_rgb_patch() -> np.ndarray:
+    rng = np.random.default_rng(seed=42)
+    return rng.uniform(low=1.0, high=254.0, size=(3, 16, 16)).astype(np.float64)
+
+
+class TestSdaRoundTrip:
+    @pytest.mark.parametrize("chunked", [False, True])
+    def test_round_trip(self, random_rgb_patch: np.ndarray, chunked: bool) -> None:
+        rgb = _rgb_dataarray(random_rgb_patch, chunked=chunked)
+        recovered = sda_to_rgb(rgb_to_sda(rgb))
+        np.testing.assert_allclose(recovered.values, random_rgb_patch, atol=1e-6)
+
+    def test_white_maps_to_zero(self) -> None:
+        white = xr.DataArray(np.full((3, 4, 4), 255.0), dims=("c", "y", "x"))
+        sda = rgb_to_sda(white)
+        np.testing.assert_allclose(sda.values, 0.0, atol=1e-6)
+
+    def test_non_negative_on_valid_rgb(self, random_rgb_patch: np.ndarray) -> None:
+        rgb = _rgb_dataarray(random_rgb_patch, chunked=False)
+        sda = rgb_to_sda(rgb)
+        assert float(sda.min()) >= -1e-9
+
+    def test_uint8_promoted_to_float(self) -> None:
+        rng = np.random.default_rng(seed=0)
+        rgb = xr.DataArray(rng.integers(0, 255, size=(3, 8, 8), dtype=np.uint8), dims=("c", "y", "x"))
+        sda = rgb_to_sda(rgb)
+        assert np.issubdtype(sda.dtype, np.floating)
+
+    def test_custom_background_round_trip(self, random_rgb_patch: np.ndarray) -> None:
+        bg = np.array([240.0, 250.0, 235.0])
+        rgb = _rgb_dataarray(random_rgb_patch, chunked=False)
+        recovered = sda_to_rgb(rgb_to_sda(rgb, background_intensity=bg), background_intensity=bg)
+        np.testing.assert_allclose(recovered.values, random_rgb_patch, atol=1e-6)
+
+
+class TestRudermanRoundTrip:
+    @pytest.mark.parametrize("chunked", [False, True])
+    def test_round_trip(self, random_rgb_patch: np.ndarray, chunked: bool) -> None:
+        rgb = _rgb_dataarray(random_rgb_patch, chunked=chunked)
+        recovered = lab_ruderman_to_rgb(rgb_to_lab_ruderman(rgb))
+        np.testing.assert_allclose(recovered.values, random_rgb_patch, atol=1e-4)
+
+
+class TestLazinessContract:
+    """Dask in -> dask out. The conversion must not eagerly compute."""
+
+    def test_rgb_to_sda_stays_lazy(self, random_rgb_patch: np.ndarray) -> None:
+        rgb = _rgb_dataarray(random_rgb_patch, chunked=True)
+        sda = rgb_to_sda(rgb)
+        assert isinstance(sda.data, da.Array)
+
+    def test_sda_to_rgb_stays_lazy(self, random_rgb_patch: np.ndarray) -> None:
+        rgb = _rgb_dataarray(random_rgb_patch, chunked=True)
+        recovered = sda_to_rgb(rgb_to_sda(rgb))
+        assert isinstance(recovered.data, da.Array)
+
+    def test_ruderman_pair_stays_lazy(self, random_rgb_patch: np.ndarray) -> None:
+        rgb = _rgb_dataarray(random_rgb_patch, chunked=True)
+        recovered = lab_ruderman_to_rgb(rgb_to_lab_ruderman(rgb))
+        assert isinstance(recovered.data, da.Array)
+
+    def test_chunked_matches_unchunked(self, random_rgb_patch: np.ndarray) -> None:
+        rgb_eager = _rgb_dataarray(random_rgb_patch, chunked=False)
+        rgb_lazy = _rgb_dataarray(random_rgb_patch, chunked=True)
+        sda_eager = rgb_to_sda(rgb_eager).values
+        sda_lazy = rgb_to_sda(rgb_lazy).values
+        np.testing.assert_allclose(sda_lazy, sda_eager, atol=1e-10)
+
+
+class TestInputValidation:
+    def test_missing_channel_dim_raises(self) -> None:
+        arr = xr.DataArray(np.zeros((4, 4, 3)), dims=("y", "x", "channel"))
+        with pytest.raises(ValueError, match="dimension named 'c'"):
+            rgb_to_sda(arr)
+
+    def test_wrong_channel_length_raises(self) -> None:
+        arr = xr.DataArray(np.zeros((4, 4, 4)), dims=("y", "x", "c"))
+        with pytest.raises(ValueError, match="length 3"):
+            rgb_to_sda(arr)
+
+    def test_invalid_background_shape_raises(self) -> None:
+        rgb = xr.DataArray(np.zeros((3, 4, 4)), dims=("c", "y", "x"))
+        with pytest.raises(ValueError, match="background_intensity"):
+            rgb_to_sda(rgb, background_intensity=np.array([1.0, 2.0]))

--- a/tests/experimental/test_stain_reference.py
+++ b/tests/experimental/test_stain_reference.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from squidpy.experimental.im._stain._constants import (
+    RUIFROK_HE,
+    STAIN_REFERENCE_SCHEMA_VERSION,
+)
+from squidpy.experimental.im._stain._reference import StainReference
+
+
+def _ruifrok_matrix() -> np.ndarray:
+    third = np.cross(RUIFROK_HE["hematoxylin"], RUIFROK_HE["eosin"])
+    third = third / np.linalg.norm(third)
+    return np.column_stack([RUIFROK_HE["hematoxylin"], RUIFROK_HE["eosin"], third])
+
+
+class TestConstruction:
+    def test_macenko_basic(self) -> None:
+        ref = StainReference(method="macenko", stain_matrix=_ruifrok_matrix())
+        assert ref.method == "macenko"
+        assert ref.version == STAIN_REFERENCE_SCHEMA_VERSION
+        assert ref.mu is None and ref.sigma is None
+        assert ref.stain_matrix.shape == (3, 3)
+
+    def test_reinhard_basic(self) -> None:
+        ref = StainReference(method="reinhard", mu=np.array([1.0, 0.5, -0.2]), sigma=np.array([0.1, 0.1, 0.1]))
+        assert ref.method == "reinhard"
+        assert ref.stain_matrix is None
+
+    def test_unknown_method_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown method"):
+            StainReference(method="not-a-method")  # type: ignore[arg-type]
+
+    def test_decomposition_requires_stain_matrix(self) -> None:
+        with pytest.raises(ValueError, match="requires stain_matrix"):
+            StainReference(method="macenko")
+
+    def test_decomposition_forbids_mu_sigma(self) -> None:
+        with pytest.raises(ValueError, match="forbids mu/sigma"):
+            StainReference(
+                method="macenko",
+                stain_matrix=_ruifrok_matrix(),
+                mu=np.zeros(3),
+                sigma=np.ones(3),
+            )
+
+    def test_reinhard_requires_mu_and_sigma(self) -> None:
+        with pytest.raises(ValueError, match="requires both mu and sigma"):
+            StainReference(method="reinhard", mu=np.zeros(3))
+
+    def test_reinhard_rejects_non_positive_sigma(self) -> None:
+        with pytest.raises(ValueError, match="strictly positive"):
+            StainReference(method="reinhard", mu=np.zeros(3), sigma=np.array([1.0, 0.0, 1.0]))
+
+    def test_reinhard_forbids_stain_matrix(self) -> None:
+        with pytest.raises(ValueError, match="forbids stain_matrix"):
+            StainReference(
+                method="reinhard",
+                mu=np.zeros(3),
+                sigma=np.ones(3),
+                stain_matrix=_ruifrok_matrix(),
+            )
+
+    def test_bad_background_intensity(self) -> None:
+        with pytest.raises(ValueError, match="background_intensity"):
+            StainReference(
+                method="macenko",
+                stain_matrix=_ruifrok_matrix(),
+                background_intensity=np.array([255.0, -1.0, 255.0]),
+            )
+
+    def test_bad_max_concentrations_shape(self) -> None:
+        with pytest.raises(ValueError, match="max_concentrations"):
+            StainReference(
+                method="macenko",
+                stain_matrix=_ruifrok_matrix(),
+                max_concentrations=np.array([1.0, 2.0, 3.0]),
+            )
+
+
+class TestPersistence:
+    def test_round_trip_macenko(self, tmp_path: Path) -> None:
+        ref = StainReference(
+            method="macenko",
+            stain_matrix=_ruifrok_matrix(),
+            max_concentrations=np.array([2.5, 2.0]),
+            fit_metadata={"seed": 0, "pyramid_level": "scale1"},
+        )
+        path = tmp_path / "ref.json"
+        ref.save(path)
+        loaded = StainReference.load(path)
+        np.testing.assert_array_equal(loaded.stain_matrix, ref.stain_matrix)
+        np.testing.assert_array_equal(loaded.max_concentrations, ref.max_concentrations)
+        np.testing.assert_array_equal(loaded.background_intensity, ref.background_intensity)
+        assert loaded.method == "macenko"
+        assert loaded.fit_metadata == ref.fit_metadata
+        assert loaded.version == STAIN_REFERENCE_SCHEMA_VERSION
+
+    def test_round_trip_vahadane(self, tmp_path: Path) -> None:
+        ref = StainReference(method="vahadane", stain_matrix=_ruifrok_matrix())
+        path = tmp_path / "ref.json"
+        ref.save(path)
+        loaded = StainReference.load(path)
+        assert loaded.method == "vahadane"
+        np.testing.assert_array_equal(loaded.stain_matrix, ref.stain_matrix)
+
+    def test_round_trip_reinhard(self, tmp_path: Path) -> None:
+        ref = StainReference(
+            method="reinhard",
+            mu=np.array([1.2, -0.3, 0.05]),
+            sigma=np.array([0.4, 0.3, 0.2]),
+        )
+        path = tmp_path / "ref.json"
+        ref.save(path)
+        loaded = StainReference.load(path)
+        np.testing.assert_array_equal(loaded.mu, ref.mu)
+        np.testing.assert_array_equal(loaded.sigma, ref.sigma)
+        assert loaded.stain_matrix is None
+
+    def test_round_trip_cohort_fields(self, tmp_path: Path) -> None:
+        wiggled = _ruifrok_matrix() + 0.01
+        wiggled /= np.linalg.norm(wiggled, axis=0)
+        per_image = {
+            "img_a": {"stain_matrix": _ruifrok_matrix()},
+            "img_b": {"stain_matrix": wiggled},
+        }
+        ref = StainReference(
+            method="macenko",
+            stain_matrix=_ruifrok_matrix(),
+            cohort_members=("img_a", "img_b"),
+            per_image_stats=per_image,
+        )
+        path = tmp_path / "ref.json"
+        ref.save(path)
+        loaded = StainReference.load(path)
+        assert loaded.cohort_members == ("img_a", "img_b")
+        assert isinstance(loaded.cohort_members, tuple)
+        np.testing.assert_array_equal(
+            loaded.per_image_stats["img_b"]["stain_matrix"],
+            per_image["img_b"]["stain_matrix"],
+        )
+
+    def test_corrupted_json_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("not json at all", encoding="utf-8")
+        with pytest.raises(ValueError, match="Could not parse"):
+            StainReference.load(path)
+
+    def test_missing_schema_marker_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text('{"method": "macenko"}', encoding="utf-8")
+        with pytest.raises(ValueError, match="schema marker"):
+            StainReference.load(path)
+
+    def test_newer_schema_version_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "future.json"
+        path.write_text(
+            '{"schema": "squidpy.stain_reference", "version": 999, "method": "macenko"}',
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="newer than this squidpy"):
+            StainReference.load(path)

--- a/tests/experimental/test_stain_validation.py
+++ b/tests/experimental/test_stain_validation.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from squidpy.experimental.im._stain._constants import RUIFROK_HE
+from squidpy.experimental.im._stain._validation import (
+    StainFittingError,
+    complement_third_column,
+    reorder_to_canonical,
+    validate_stain_matrix,
+)
+
+
+def _canonical_he() -> np.ndarray:
+    return np.column_stack([RUIFROK_HE["hematoxylin"], RUIFROK_HE["eosin"]])
+
+
+def _canonical_full() -> np.ndarray:
+    return complement_third_column(_canonical_he())
+
+
+class TestReorderToCanonical:
+    def test_already_canonical_unchanged(self) -> None:
+        W = _canonical_he()
+        out = reorder_to_canonical(W)
+        np.testing.assert_allclose(out, W, atol=1e-12)
+
+    def test_swapped_columns_restored(self) -> None:
+        W = _canonical_he()
+        swapped = W[:, ::-1]
+        out = reorder_to_canonical(swapped)
+        np.testing.assert_allclose(out, W, atol=1e-12)
+
+    def test_sign_flipped_columns_restored(self) -> None:
+        W = _canonical_he()
+        flipped = W.copy()
+        flipped[:, 0] *= -1.0
+        flipped[:, 1] *= -1.0
+        out = reorder_to_canonical(flipped)
+        np.testing.assert_allclose(out, W, atol=1e-12)
+
+    def test_three_column_input_preserves_third(self) -> None:
+        W = _canonical_full()
+        swapped = W.copy()
+        swapped[:, [0, 1]] = swapped[:, [1, 0]]
+        out = reorder_to_canonical(swapped)
+        np.testing.assert_allclose(out[:, :2], W[:, :2], atol=1e-12)
+        np.testing.assert_allclose(out[:, 2], swapped[:, 2], atol=1e-12)
+
+
+class TestComplementThirdColumn:
+    def test_third_column_is_unit_norm_and_orthogonal(self) -> None:
+        W = complement_third_column(_canonical_he())
+        np.testing.assert_allclose(np.linalg.norm(W[:, 2]), 1.0, atol=1e-12)
+        np.testing.assert_allclose(np.dot(W[:, 2], W[:, 0]), 0.0, atol=1e-12)
+        np.testing.assert_allclose(np.dot(W[:, 2], W[:, 1]), 0.0, atol=1e-12)
+        assert W.shape == (3, 3)
+
+    def test_collinear_inputs_raise(self) -> None:
+        W = np.column_stack([RUIFROK_HE["hematoxylin"], RUIFROK_HE["hematoxylin"]])
+        with pytest.raises(StainFittingError, match="collinear"):
+            complement_third_column(W)
+
+
+class TestValidateStainMatrix:
+    def test_canonical_passes(self) -> None:
+        validate_stain_matrix(_canonical_full())
+
+    def test_rotated_h_column_raises(self) -> None:
+        W = _canonical_full().copy()
+        # Far-from-H direction (cosine ~0.29 with hematoxylin, ~73 degrees).
+        W[:, 0] = np.array([0.0, 0.0, 1.0])
+        with pytest.raises(StainFittingError, match="hematoxylin"):
+            validate_stain_matrix(W, image_key="bad_slide")
+
+    def test_image_key_attached(self) -> None:
+        W = _canonical_full().copy()
+        # Far-from-H direction (cosine ~0.29 with hematoxylin, ~73 degrees).
+        W[:, 0] = np.array([0.0, 0.0, 1.0])
+        with pytest.raises(StainFittingError) as excinfo:
+            validate_stain_matrix(W, image_key="bad_slide")
+        assert excinfo.value.image_key == "bad_slide"
+        assert "[bad_slide]" in str(excinfo.value)
+
+    def test_rank_deficient_raises(self) -> None:
+        # Replace E with H so the matrix has only one independent stain
+        # direction in the H/E plane, then put a tiny third column.
+        W = np.column_stack([RUIFROK_HE["hematoxylin"], RUIFROK_HE["hematoxylin"], np.array([1e-12, 0.0, 0.0])])
+        with pytest.raises(StainFittingError, match="near-zero column|rank-deficient"):
+            validate_stain_matrix(W)
+
+    def test_zero_column_raises(self) -> None:
+        W = _canonical_full().copy()
+        W[:, 2] = 0.0
+        with pytest.raises(StainFittingError, match="near-zero column"):
+            validate_stain_matrix(W)
+
+    def test_wrong_shape_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"shape \(3, 3\)"):
+            validate_stain_matrix(np.zeros((3, 2)))


### PR DESCRIPTION
## Summary

Substrate for a new histopathology stain-normalization module. Targets Squidpy 2.0. **No public API surface** in this PR — every new symbol lives under the private `squidpy.experimental.im._stain` namespace and there are no re-exports. Fitting, apply, cohort aggregation, and augmentation land in follow-up PRs (this is PR 1 of 7 per the design plan).

What ships:

- **`_constants.py`** — Ruifrok H/E/DAB canonical stain vectors (derived from `skimage.color.rgb_from_hed` for ecosystem consistency), Ruderman RGB ↔ LMS ↔ Lab matrices, HistomicsTK-compatible SDA scale, `StainMethod` `StrEnum`, near-zero norm threshold, schema version.
- **`_conversion.py`** — `rgb_to_sda` / `sda_to_rgb` and `rgb_to_lab_ruderman` / `lab_ruderman_to_rgb` on `xr.DataArray`. Each public function compiles to a single fused `apply_ufunc` per chunk; numpy- and dask-backed inputs both stay on the same code path; dask-backed inputs stay lazy end-to-end.
- **`_reference.py`** — frozen `StainReference` dataclass holding either a `(3, 3)` stain matrix (Macenko/Vahadane) or `mu`/`sigma` channel statistics (Reinhard), plus optional cohort fields. JSON `save` / `load` with schema versioning; ndarray fields encode via a single recursive `_encode`/`_decode` pair shared with `per_image_stats`.
- **`_validation.py`** — `StainFittingError` (carries `image_key` for cohort attribution), `validate_stain_matrix`, `reorder_to_canonical`, `complement_third_column`.

Design decisions worth highlighting:

- Lives under `experimental/im/` alongside the existing SpatialData-native modules (`_detect_tissue`, `_qc_image`, `_make_tiles`, `_feature`). The eventual `experimental/im → im` promotion is a separate v2.0 effort.
- Conversion primitives are `xr.DataArray`-native from the start, not numpy-only, so PR 2's lazy apply path reuses them unchanged.
- SDA uses `(rgb + 1) / (I_0 + 1)` so that pixels at the white point map exactly to zero. Documented in `rgb_to_sda` docstring.
- No bespoke I/O. Image data is reached through `sdata.images[key]` (starting in PR 2 via the existing `experimental/im/_utils.py::get_element_data` helper); this module never adds a loader.

## Test plan

53 unit tests across four files in `tests/experimental/test_stain_*.py`, all passing:

- [x] Color-space round-trips below 1e-6 for SDA and below 1e-4 for the Ruderman pair, on both numpy-backed and dask-backed `xr.DataArray` inputs.
- [x] Lazy contract: dask in, dask out, no compute triggered; chunked output matches unchunked output within tolerance.
- [x] White pixels map exactly to zero in SDA; uint8 inputs promote to float; custom backgrounds round-trip.
- [x] `StainReference` cross-field validation (decomposition vs. Reinhard); strictly-positive sigma; finite backgrounds; cohort fields tuple-typed; schema marker required on load; newer schema versions rejected with a clear error.
- [x] JSON round-trips array-exact for all three methods and for `per_image_stats`.
- [x] `reorder_to_canonical` restores swapped and sign-flipped H/E columns; preserves the third column when present.
- [x] `complement_third_column` produces a unit-norm column orthogonal to both inputs; raises on collinear inputs.
- [x] `validate_stain_matrix` raises `StainFittingError` with the correct `image_key` on rotated, rank-deficient, and zero-column matrices; passes on canonical input.
- [x] `ruff check`, `ruff format`, and the configured pre-commit hooks all clean.

## Follow-up PRs (for context, not part of this PR)

PR 2 ships Reinhard end-to-end and the public `fit_stain_reference` / `normalize_stain` surface; PR 3 adds Macenko + Vahadane + `decompose_stains`; PR 4 adds cohort fitting, mask support, and the QC report; PR 5 adds lazy chunked apply and backend dispatch; PR 6 adds `augment_stain`; PR 7 ships the tutorial and migration docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)