### PR TITLE
chore: add flaky marker to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,11 +108,11 @@ optional-dependencies.leiden = [
 ]
 optional-dependencies.test = [
   "coverage[toml]>=7",
-  "flaky",
   "pytest>=7",
   # Just for VS Code
   "pytest-cov>=4",
   "pytest-mock>=3.5",
+  "pytest-rerunfailures",
   "pytest-timeout>=2.1",
   "pytest-xdist>=3",
   "scanpy[leiden]",
@@ -262,7 +262,6 @@ addopts = [
 markers = [
   "internet: tests that require internet",
   "gpu: tests that require GPU",
-  "flaky: tests that may be retried",
 ]
 
 [tool.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ optional-dependencies.leiden = [
 ]
 optional-dependencies.test = [
   "coverage[toml]>=7",
+  "flaky",
   "pytest>=7",
   # Just for VS Code
   "pytest-cov>=4",
@@ -261,6 +262,7 @@ addopts = [
 markers = [
   "internet: tests that require internet",
   "gpu: tests that require GPU",
+  "flaky: tests that may be retried",
 ]
 
 [tool.coverage]

--- a/tests/utils/test_parallelize.py
+++ b/tests/utils/test_parallelize.py
@@ -67,7 +67,7 @@ def func(request) -> Callable:
 # in case of failure.
 
 
-@pytest.mark.flaky(max_runs=5)
+@pytest.mark.flaky(reruns=4)
 @pytest.mark.timeout(5)
 @pytest.mark.parametrize(
     "backend",


### PR DESCRIPTION
similar to the gpu marker we needed to add even though the CI's worked here: https://github.com/scverse/squidpy/pull/1140. We need to add the flaky marker explicitly here. 