### PR TITLE
chore: switch to dependency groups

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -1,52 +1,38 @@
 [envs.default]
 installer = "uv"
-features = ["dev"]
+dependency-groups = ["dev"]
 
 [envs.docs]
-features = ["docs"]
-extra-dependencies = [
-    "setuptools",
-]
-[envs.docs.scripts]
-build = "sphinx-build -M html docs docs/_build -W {args}"
-open = "python3 -m webbrowser -t docs/_build/html/index.html"
-clean = "git clean -fdX -- {args:docs}"
+dependency-groups = ["docs"]
+scripts.build = "sphinx-build -M html docs docs/_build -W {args}"
+scripts.open = "python3 -m webbrowser -t docs/_build/html/index.html"
+scripts.clean = "git clean -fdX -- {args:docs}"
 
 [envs.data]
-[envs.data.scripts]
-download = "python ./.scripts/ci/download_data.py {args}"
-
+scripts.download = "python ./.scripts/ci/download_data.py {args}"
 
 [envs.hatch-test]
-features = ["test"]
+dependency-groups = ["test"]
 extra-dependencies = ["diff-cover"]
-[envs.hatch-test.scripts]
-# defaults (only `cov-report` is overridden)
-run = "pytest{env:HATCH_TEST_ARGS:} -p no:cov {args}"
-run-cov = "coverage run -m pytest{env:HATCH_TEST_ARGS:} -p no:cov {args}"
-cov-combine = ["coverage combine"]
-cov-report = [
+matrix = [
+  { deps = ["stable"], python = ["3.11", "3.12", "3.13"] },
+  { deps = ["pre"], python = ["3.13"] },
+]
+overrides.matrix.deps.env-vars = [
+  { key = "UV_PRERELEASE", value = "allow", if = ["pre"] },
+]
+# default commands (only `cov-report` is overridden)
+scripts.run = "pytest{env:HATCH_TEST_ARGS:} -p no:cov {args}"
+scripts.run-cov = "coverage run -m pytest{env:HATCH_TEST_ARGS:} -p no:cov {args}"
+scripts.cov-combine = ["coverage combine"]
+scripts.cov-report = [
     "coverage report",
     "coverage xml -o coverage.xml",
     "diff-cover --compare-branch origin/main coverage.xml",
 ]
 # extra commands
-cov-erase = "coverage erase"
-download = "python ./.scripts/ci/download_data.py {args}"
-
-
-[[envs.hatch-test.matrix]]
-deps = ["stable"]
-python = ["3.11", "3.12", "3.13"]
-
-[[envs.hatch-test.matrix]]
-deps = ["pre"]
-python = ["3.13"]
-
-[envs.hatch-test.overrides]
-matrix.deps.env-vars = [
-  { key = "UV_PRERELEASE", value = "allow", if = ["pre"] },
-]
+scripts.cov-erase = "coverage erase"
+scripts.download = "python ./.scripts/ci/download_data.py {args}"
 
 [envs.notebooks]
 extra-dependencies = [
@@ -58,8 +44,5 @@ extra-dependencies = [
     "napari-spatialdata",
 ]
 extras = ["docs"]
-
-[envs.notebooks.scripts]
-
-setup-squidpy-kernel = "python -m ipykernel install --user --name=squidpy"
-run-notebooks = "python ./.scripts/ci/run_notebooks.py docs/notebooks"
+scripts.setup-squidpy-kernel = "python -m ipykernel install --user --name=squidpy"
+scripts.run-notebooks = "python ./.scripts/ci/run_notebooks.py docs/notebooks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,17 @@ dependencies = [
   "xarray>=2024.10",
   "zarr>=3",
 ]
-optional-dependencies.dev = [
+optional-dependencies.leiden = [
+  "leidenalg",
+  "spatialleiden>=0.4",
+]
+urls."Bug Tracker" = "https://github.com/scverse/squidpy/issues"
+urls.Documentation = "https://squidpy.readthedocs.io"
+urls.Home-page = "https://github.com/scverse/squidpy"
+urls.Source = "https://github.com/scverse/squidpy"
+
+[dependency-groups]
+dev = [
   "hatch>=1.9",
   "ipykernel",
   "ipywidgets",
@@ -86,7 +96,18 @@ optional-dependencies.dev = [
   "pre-commit>=3",
   "ruff",
 ]
-optional-dependencies.docs = [
+test = [
+  "coverage[toml]>=7",
+  "pytest>=7",
+  # Just for VS Code
+  "pytest-cov>=4",
+  "pytest-mock>=3.5",
+  "pytest-rerunfailures",
+  "pytest-timeout>=2.1",
+  "pytest-xdist>=3",
+  "scanpy[leiden]",
+]
+docs = [
   "docutils<0.22",                    # Pin to avoid sphinx-tabs KeyError with backrefs
   "ipython",
   "ipywidgets>=8",
@@ -102,25 +123,6 @@ optional-dependencies.docs = [
   "sphinxcontrib-bibtex>=2.3",
   "sphinxcontrib-spelling>=7.6.2",
 ]
-optional-dependencies.leiden = [
-  "leidenalg",
-  "spatialleiden>=0.4",
-]
-optional-dependencies.test = [
-  "coverage[toml]>=7",
-  "pytest>=7",
-  # Just for VS Code
-  "pytest-cov>=4",
-  "pytest-mock>=3.5",
-  "pytest-rerunfailures",
-  "pytest-timeout>=2.1",
-  "pytest-xdist>=3",
-  "scanpy[leiden]",
-]
-urls."Bug Tracker" = "https://github.com/scverse/squidpy/issues"
-urls.Documentation = "https://squidpy.readthedocs.io"
-urls.Home-page = "https://github.com/scverse/squidpy"
-urls.Source = "https://github.com/scverse/squidpy"
 
 [tool.setuptools]
 package-dir = { "" = "src" }


### PR DESCRIPTION
Switches to dependency groups so the development dependency groups `test`/`dev`/`docs` are no longer “features” that users can see and install when installing squidpy.

Also formatted `hatch.toml` in the way that pyproject-fmt does. I can undo that if you don’t like it.