### PR TITLE
Parallelize spatial neighbors

### DIFF
--- a/src/squidpy/_docs.py
+++ b/src/squidpy/_docs.py
@@ -380,6 +380,15 @@ set_diag
     Whether to set the diagonal of the connectivities to ``1.0``.
 key_added
     Key which controls where the results are saved if ``copy = False``."""
+_n_jobs_libraries = """\
+n_jobs
+    Number of parallel jobs used to build the per-library graphs when ``library_key``
+    is set. Each library's graph is computed independently, so this only has an effect
+    for multi-library data. ``1`` (default) builds the graphs sequentially and does not
+    change behavior; ``-1`` uses all available CPUs. Has no effect when ``library_key``
+    is ``None``. Speedup is sub-linear (memory-bandwidth bound), and process-based
+    backends pay a one-time worker start-up cost, so parallelism mainly pays off for
+    many large libraries."""
 _spatial_neighbors_returns = """\
 If ``copy = True``, returns a :class:`~squidpy.gr.SpatialNeighborsResult` with the
 spatial connectivities and distances matrices.
@@ -435,5 +444,6 @@ d = DocstringProcessor(
     library_key=_library_key,
     sdata_params=_sdata_params,
     graph_common_params=_graph_common_params,
+    n_jobs_libraries=_n_jobs_libraries,
     spatial_neighbors_returns=_spatial_neighbors_returns,
 )

--- a/src/squidpy/_utils.py
+++ b/src/squidpy/_utils.py
@@ -245,12 +245,11 @@ def parallelize(
 
 def thread_map(
     fn: Callable[..., Any],
-    items: Iterable[Any],
+    items: Sequence[Any],
     *,
     n_jobs: int = 1,
     show_progress_bar: bool = False,
     unit: str = "item",
-    total: int | None = None,
 ) -> list[Any]:
     """Map *fn* over *items* using a thread pool with an optional progress bar.
 
@@ -259,15 +258,13 @@ def thread_map(
     fn
         Callable applied to each element of *items*.
     items
-        Iterable of inputs passed one-by-one to *fn*.
+        Sequence of inputs passed one-by-one to *fn*.
     n_jobs
         Number of worker threads. ``1`` runs sequentially (no pool overhead).
     show_progress_bar
         Whether to display a ``tqdm`` progress bar.
     unit
         Label shown next to the ``tqdm`` counter.
-    total
-        Length hint passed to ``tqdm`` when *items* has no ``__len__``.
 
     Returns
     -------
@@ -275,6 +272,12 @@ def thread_map(
         Results in the same order as *items*.
     """
     from concurrent.futures import ThreadPoolExecutor
+
+    if n_jobs == 1:
+        it: Iterable[Any] = map(fn, items)
+        if show_progress_bar and tqdm is not None:
+            it = tqdm(it, total=len(items), unit=unit)
+        return list(it)
 
     with ThreadPoolExecutor(max_workers=n_jobs) as pool:
         it = pool.map(fn, items)

--- a/src/squidpy/gr/_build.py
+++ b/src/squidpy/gr/_build.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from anndata import AnnData
 from anndata.utils import make_index_unique
+from joblib import Parallel, delayed
 from numba import njit
 from shapely import LineString, MultiPolygon, Polygon
 from spatialdata import SpatialData
@@ -149,6 +150,7 @@ def spatial_neighbors(
     set_diag: bool = False,
     key_added: str = "spatial",
     copy: bool = False,
+    n_jobs: int = 1,
 ) -> SpatialNeighborsResult | None:
     """
     Create a graph from spatial coordinates.
@@ -217,6 +219,7 @@ def spatial_neighbors(
     key_added
         Key which controls where the results are saved if ``copy = False``.
     %(copy)s
+    %(n_jobs_libraries)s
 
     Notes
     -----
@@ -326,6 +329,7 @@ def spatial_neighbors(
         library_key=library_key,
         key_added=key_added,
         copy=copy,
+        n_jobs=n_jobs,
     )
 
 
@@ -396,6 +400,7 @@ def spatial_neighbors_from_builder(
     library_key: str | None = None,
     key_added: str = "spatial",
     copy: bool = False,
+    n_jobs: int = 1,
 ) -> SpatialNeighborsResult | None:
     """Create a graph from spatial coordinates using an explicit builder instance.
 
@@ -428,6 +433,7 @@ def spatial_neighbors_from_builder(
     key_added
         Key which controls where the results are saved if ``copy = False``.
     %(copy)s
+    %(n_jobs_libraries)s
 
     Returns
     -------
@@ -455,6 +461,7 @@ def spatial_neighbors_from_builder(
         library_key=library_key,
         key_added=key_added,
         copy=copy,
+        n_jobs=n_jobs,
     )
 
 
@@ -492,6 +499,7 @@ def spatial_neighbors_knn(
     set_diag: bool = False,
     key_added: str = "spatial",
     copy: bool = False,
+    n_jobs: int = 1,
 ) -> SpatialNeighborsResult | None:
     """Create a k-nearest-neighbor graph from spatial coordinates.
 
@@ -510,6 +518,7 @@ def spatial_neighbors_knn(
         sparser, more local graph; larger values connect broader neighborhoods.
     %(graph_common_params)s
     %(copy)s
+    %(n_jobs_libraries)s
 
     Returns
     -------
@@ -541,6 +550,7 @@ def spatial_neighbors_knn(
         library_key=library_key,
         key_added=key_added,
         copy=copy,
+        n_jobs=n_jobs,
     )
 
 
@@ -558,6 +568,7 @@ def spatial_neighbors_radius(
     set_diag: bool = False,
     key_added: str = "spatial",
     copy: bool = False,
+    n_jobs: int = 1,
 ) -> SpatialNeighborsResult | None:
     """Create a radius-based graph from spatial coordinates.
 
@@ -579,6 +590,7 @@ def spatial_neighbors_radius(
         specified distance interval.
     %(graph_common_params)s
     %(copy)s
+    %(n_jobs_libraries)s
 
     Returns
     -------
@@ -610,6 +622,7 @@ def spatial_neighbors_radius(
         library_key=library_key,
         key_added=key_added,
         copy=copy,
+        n_jobs=n_jobs,
     )
 
 
@@ -627,6 +640,7 @@ def spatial_neighbors_delaunay(
     set_diag: bool = False,
     key_added: str = "spatial",
     copy: bool = False,
+    n_jobs: int = 1,
 ) -> SpatialNeighborsResult | None:
     """Create a Delaunay triangulation graph from spatial coordinates.
 
@@ -652,6 +666,7 @@ def spatial_neighbors_delaunay(
             - ``None``: keep every Delaunay edge.
     %(graph_common_params)s
     %(copy)s
+    %(n_jobs_libraries)s
 
     Returns
     -------
@@ -683,6 +698,7 @@ def spatial_neighbors_delaunay(
         library_key=library_key,
         key_added=key_added,
         copy=copy,
+        n_jobs=n_jobs,
     )
 
 
@@ -701,6 +717,7 @@ def spatial_neighbors_grid(
     set_diag: bool = False,
     key_added: str = "spatial",
     copy: bool = False,
+    n_jobs: int = 1,
 ) -> SpatialNeighborsResult | None:
     """Create a grid-based graph from spatial coordinates.
 
@@ -735,6 +752,7 @@ def spatial_neighbors_grid(
         distances.
     %(graph_common_params)s
     %(copy)s
+    %(n_jobs_libraries)s
 
     Returns
     -------
@@ -769,6 +787,7 @@ def spatial_neighbors_grid(
         library_key=library_key,
         key_added=key_added,
         copy=copy,
+        n_jobs=n_jobs,
     )
 
 
@@ -780,6 +799,7 @@ def _run_spatial_neighbors(
     library_key: str | None = None,
     key_added: str = "spatial",
     copy: bool = False,
+    n_jobs: int = 1,
 ) -> SpatialNeighborsResult | None:
     """Shared core: build the graph from a resolved builder and save results."""
     if library_key is not None:
@@ -791,11 +811,29 @@ def _run_spatial_neighbors(
 
     start = logg.info(f"Creating graph using `{builder.transform}` transform and `{len(libs)}` libraries.")
     if library_key is not None:
-        mats: list[tuple[Any, Any]] = []
+        # Extract the per-library coordinate arrays once. Subsetting the full AnnData
+        # inside the loop recomputes the library mask repeatedly (twice per library in
+        # the previous implementation) and creates a view per library, which dominates
+        # the runtime for many cells. Slicing the coordinate array by precomputed
+        # category codes is far cheaper and, because the resulting arrays are small,
+        # makes the per-library graph construction cheap to parallelize.
+        codes = adata.obs[library_key].cat.codes.to_numpy()
+        coords = adata.obsm[spatial_key]
+        per_lib_coords: list[np.ndarray] = []
         ixs: list[int] = []
-        for lib in libs:
-            ixs.extend(np.where(adata.obs[library_key] == lib)[0])
-            mats.append(builder.build(adata[adata.obs[library_key] == lib].obsm[spatial_key]))
+        for code in range(len(libs)):
+            idx = np.where(codes == code)[0]
+            per_lib_coords.append(np.ascontiguousarray(coords[idx]))
+            ixs.extend(idx.tolist())
+
+        if n_jobs == 1:
+            mats: list[tuple[Any, Any]] = [builder.build(c) for c in per_lib_coords]
+        else:
+            # Parallelize across libraries: each graph is independent. The coordinate
+            # arrays are small, so the default (loky) backend memmaps them to workers
+            # at negligible cost; sub-linear speedups are expected (memory-bandwidth
+            # bound) and a one-time worker start-up cost applies.
+            mats = Parallel(n_jobs=n_jobs)(delayed(builder.build)(c) for c in per_lib_coords)
         adj, dst = builder.combine(mats, ixs)
     else:
         adj, dst = builder.build(adata.obsm[spatial_key])

--- a/src/squidpy/gr/_build.py
+++ b/src/squidpy/gr/_build.py
@@ -817,21 +817,21 @@ def _run_spatial_neighbors(
         codes = adata.obs[library_key].cat.codes.to_numpy()
         coords = adata.obsm[spatial_key]
         per_lib_coords: list[np.ndarray] = []
-        ixs: list[int] = []
+        idxs: list[int] = []
         for code in range(len(libs)):
             idx = np.where(codes == code)[0]
             per_lib_coords.append(np.ascontiguousarray(coords[idx]))
-            ixs.extend(idx.tolist())
+            idxs.extend(idx.tolist())
 
         if n_jobs == 1:
-            mats: list[tuple[Any, Any]] = [builder.build(c) for c in per_lib_coords]
+            mats = [builder.build(c) for c in per_lib_coords]
         else:
             # Parallelize across libraries: each graph is independent. The coordinate
             # arrays are small, so the default (loky) backend memmaps them to workers
             # at negligible cost; sub-linear speedups are expected (memory-bandwidth
             # bound) and a one-time worker start-up cost applies.
             mats = Parallel(n_jobs=n_jobs)(delayed(builder.build)(c) for c in per_lib_coords)
-        adj, dst = builder.combine(mats, ixs)
+        adj, dst = builder.combine(mats, idxs)
     else:
         adj, dst = builder.build(adata.obsm[spatial_key])
 

--- a/src/squidpy/gr/_build.py
+++ b/src/squidpy/gr/_build.py
@@ -10,7 +10,6 @@ import numpy as np
 import pandas as pd
 from anndata import AnnData
 from anndata.utils import make_index_unique
-from joblib import Parallel, delayed
 from numba import njit
 from shapely import LineString, MultiPolygon, Polygon
 from spatialdata import SpatialData
@@ -27,7 +26,7 @@ from spatialdata.models.models import (
 from squidpy._constants._constants import CoordType, Transform
 from squidpy._constants._pkg_constants import Key
 from squidpy._docs import d, inject_docs
-from squidpy._utils import NDArrayA
+from squidpy._utils import NDArrayA, thread_map
 from squidpy._validators import assert_positive
 from squidpy.gr._utils import (
     _assert_categorical_obs,
@@ -823,14 +822,12 @@ def _run_spatial_neighbors(
             per_lib_coords.append(np.ascontiguousarray(coords[idx]))
             idxs.extend(idx.tolist())
 
-        if n_jobs == 1:
-            mats = [builder.build(c) for c in per_lib_coords]
-        else:
-            # Parallelize across libraries: each graph is independent. The coordinate
-            # arrays are small, so the default (loky) backend memmaps them to workers
-            # at negligible cost; sub-linear speedups are expected (memory-bandwidth
-            # bound) and a one-time worker start-up cost applies.
-            mats = Parallel(n_jobs=n_jobs)(delayed(builder.build)(c) for c in per_lib_coords)
+        mats = thread_map(
+            builder.build,
+            per_lib_coords,
+            n_jobs=n_jobs,
+            unit="library",
+        )
         adj, dst = builder.combine(mats, idxs)
     else:
         adj, dst = builder.build(adata.obsm[spatial_key])

--- a/src/squidpy/gr/_build.py
+++ b/src/squidpy/gr/_build.py
@@ -130,8 +130,6 @@ def _resolve_graph_builder(
     return KNNBuilder(n_neighs=n_neighs, **common, percentile=percentile)
 
 
-
-
 @d.dedent
 @inject_docs(t=Transform, c=CoordType)
 def spatial_neighbors(
@@ -811,12 +809,11 @@ def _run_spatial_neighbors(
 
     start = logg.info(f"Creating graph using `{builder.transform}` transform and `{len(libs)}` libraries.")
     if library_key is not None:
-        # Extract the per-library coordinate arrays once. Subsetting the full AnnData
-        # inside the loop recomputes the library mask repeatedly (twice per library in
-        # the previous implementation) and creates a view per library, which dominates
-        # the runtime for many cells. Slicing the coordinate array by precomputed
-        # category codes is far cheaper and, because the resulting arrays are small,
-        # makes the per-library graph construction cheap to parallelize.
+        # Extract the per-library coordinate arrays once.
+        # Subsetting the full AnnData inside the loop recomputes the library mask repeatedly and
+        # creates a view per library, which dominates the runtime for many cells.
+        # Slicing the coordinate array by precomputed category codes is far cheaper and,
+        # because the resulting arrays are small, makes the per-library graph construction cheap to parallelize.
         codes = adata.obs[library_key].cat.codes.to_numpy()
         coords = adata.obsm[spatial_key]
         per_lib_coords: list[np.ndarray] = []

--- a/src/squidpy/gr/neighbors.py
+++ b/src/squidpy/gr/neighbors.py
@@ -9,7 +9,6 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from itertools import chain
 from typing import Any, Generic, TypeVar, cast
 
 import numpy as np
@@ -24,7 +23,7 @@ from scipy.sparse import (
     spmatrix,
 )
 from scipy.spatial import Delaunay
-from sklearn.metrics.pairwise import cosine_similarity, euclidean_distances
+from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.neighbors import NearestNeighbors
 
 from squidpy._constants._constants import CoordType, Transform
@@ -318,13 +317,8 @@ class DelaunayBuilder(GraphBuilderCSR):
         indptr, indices = tri.vertex_neighbor_vertices
         adj = csr_matrix((np.ones_like(indices, dtype=np.float32), indices, indptr), shape=(N, N))
 
-        # fmt: off
-        dists = np.array(list(chain(*(
-            euclidean_distances(coords[indices[indptr[i] : indptr[i + 1]], :], coords[np.newaxis, i, :])
-            for i in range(N)
-            if len(indices[indptr[i] : indptr[i + 1]])
-        )))).squeeze()
-        # fmt: on
+        rows = np.repeat(np.arange(N), np.diff(indptr))
+        dists = np.linalg.norm(coords[rows] - coords[indices], axis=1)
         dst = csr_matrix((dists, indices, indptr), shape=(N, N))
 
         adj.setdiag(1.0 if self.set_diag else adj.diagonal())

--- a/src/squidpy/gr/neighbors.py
+++ b/src/squidpy/gr/neighbors.py
@@ -136,9 +136,18 @@ class GraphBuilderCSR(GraphBuilder[NDArrayA, csr_matrix], ABC):
         mats: Sequence[tuple[csr_matrix, csr_matrix]],
         ixs: Sequence[int],
     ) -> tuple[csr_matrix, csr_matrix]:
-        order = cast(list[int], np.argsort(ixs).tolist())
-        adj = block_diag([m[0] for m in mats], format="csr")[order, :][:, order]
-        dst = block_diag([m[1] for m in mats], format="csr")[order, :][:, order]
+        adj = block_diag([m[0] for m in mats], format="csr")
+        dst = block_diag([m[1] for m in mats], format="csr")
+        # ``block_diag`` stacks the per-library blocks in library order. Only when
+        # libraries are interleaved in the original observation order do we need to
+        # permute rows/columns back. Skipping this reordering when ``ixs`` is already
+        # sorted (the common case of contiguous libraries) avoids two full fancy-index
+        # copies of a potentially very large sparse matrix.
+        ixs_arr = np.asarray(ixs)
+        if ixs_arr.size and np.any(np.diff(ixs_arr) < 0):
+            order = np.argsort(ixs_arr)
+            adj = adj[order, :][:, order]
+            dst = dst[order, :][:, order]
         return cast(csr_matrix, adj), cast(csr_matrix, dst)
 
 


### PR DESCRIPTION
## Description

This PR addresses two performance leverages in sptial_neighbors:
 * extract per-library sub-matrices upfront and once (most important)
 * enable per-library parallelism with joblib (relatively high per-worker overhead, only worthwhile with many samples)

The first step brings down the runtime by ~50% in my real-world dataset.
Parallelism doesn't add a ton, but still slightly improves the wall time. It really depends on the dataset how much it adds, therefore I left the default at `n_jobs=1`. 

When working with spatialdata, there's an additional bottleneck in `_prepare_spatial_neighbors_input` that I'll follow up on separately. 

## How has this been tested?

- unit tests pass
- manually on a real-world dataset

## Closes

no related issue