### PR TITLE
ci: bump codecov-action to v6 to fix signature verification

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -216,7 +216,7 @@ jobs:
           uvx hatch run hatch-test.py3.13-stable:cov-report
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
`codecov-action@v5` verifies the codecov CLI binary against Codecov's old Keybase key, which they bricked after migrating to a new account. The upload step now fails with `Could not verify signature`, and because `fail_ci_if_error: true` this hard-fails the Coverage job on every PR.

`@v6` (= 6.0.2) ships the updated key. One-line pin bump.

Ref: https://github.com/codecov/codecov-action/issues/1956