### PR TITLE
ci: install codecov CLI from PyPI to avoid flaky keybase.io key fetch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -216,7 +216,7 @@ jobs:
           uvx hatch run hatch-test.py3.13-stable:cov-report
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -220,6 +220,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+          use_pypi: true
 
 
   # Check that all tests defined above pass. This makes it easy to set a single "required" test in branch


### PR DESCRIPTION
Follow-up to #1203. `codecov-action@v6` fixed the bricked-key problem, but the action still imports the signing key from **keybase.io at runtime** (`codecov.sh`: `curl https://keybase.io/codecovsecops/pgp_keys.asc`). keybase.io is unreliable - when that fetch times out the GPG step fails with `no valid OpenPGP data found`, and with `fail_ci_if_error: true` the Coverage job hard-fails. Seen on #1117's run: https://github.com/scverse/squidpy/actions/runs/27140601219/job/80104717511

`use_pypi: true` installs the CLI from PyPI instead of `cli.codecov.io`, skipping the keybase key fetch entirely while still sourcing the CLI from a trusted channel.

Ref: https://github.com/codecov/codecov-action/issues/1956