### PR TITLE
test: cap matplotlib<3.11 to stabilize image-comparison baselines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,10 @@ dev = [
 ]
 test = [
   "coverage[toml]>=7",
+  # Image-comparison baselines are matplotlib-version-sensitive; matplotlib 3.11.0 (released
+  # 2026-06-12) shifts scatter/alpha rendering past the RMS tolerance. Cap for tests only
+  # (the runtime dependency stays open) until the baselines are regenerated against 3.11.
+  "matplotlib<3.11",
   "pytest>=7",
   # Just for VS Code
   "pytest-cov>=4",


### PR DESCRIPTION
matplotlib 3.11.0 (released 2026-06-12) shifts scatter/alpha rasterization past the RMS tolerance, failing `test_plot_spatial_scatter_categorical_alpha` (RMS 51.18 vs tol 50) on the `hatch-test ...-stable` envs. This breaks CI **repo-wide** — `main` and every open PR go red once `uv` resolves 3.11.

Cap `matplotlib<3.11` in the **test dependency-group only**; the runtime dependency stays open, so users and downstream libraries still resolve 3.11. Temporary until the baseline is regenerated against 3.11.

Mirrors scverse/spatialdata-plot#713.