### PR TITLE
feat: finalize cells SpatialData dataset wiring

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -115,6 +115,8 @@ import squidpy as sq
     datasets.visium_hne_image
     datasets.visium_hne_image_crop
     datasets.visium_fluo_image_crop
+    datasets.visium_hne_sdata
+    datasets.cells
 ```
 
 ## Extensibility

--- a/src/squidpy/datasets/datasets.yaml
+++ b/src/squidpy/datasets/datasets.yaml
@@ -160,7 +160,7 @@ datasets:
     files:
       - name: cells.zip
         s3_key: cells.zip
-        sha256: null
+        sha256: dc9613cb9e16fd2cd8d83f3a9586eeda4af5ba8ba366f1066efb51305820c5fb
 
   # ===========================================================================
   # 10x Genomics Visium datasets (3 files each)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -382,6 +382,11 @@ def sdata_hne():
     return sq.datasets.visium_hne_sdata()
 
 
+@pytest.fixture()
+def sdata_cells():
+    return sq.datasets.cells()
+
+
 def _decorate(fn: Callable, clsname: str, name: str | None = None) -> Callable:
     @wraps(fn)
     def save_and_compare(self, *args, **kwargs):


### PR DESCRIPTION
Follow-up to #1211 that finalizes the `cells` SpatialData dataset wiring.

## Changes
- **`datasets.yaml`**: set `cells.zip` `sha256` (was `null`) to `dc9613cb9e16fd2cd8d83f3a9586eeda4af5ba8ba366f1066efb51305820c5fb`, so downloads are integrity-checked like every other dataset. Verified by clearing the cache and re-downloading — pooch validates against the hash with no mismatch.
- **`docs/api.md`**: add `datasets.visium_hne_sdata` and `datasets.cells` to the datasets autosummary. Both SpatialData datasets were missing from the [API docs](https://squidpy.readthedocs.io/en/latest/api.html#module-squidpy.datasets).
- **`tests/conftest.py`**: add `sdata_cells` fixture mirroring `sdata_hne`, so tests can use the cells dataset.