### PR TITLE
ci: test Python 3.14

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -103,7 +103,7 @@ jobs:
           - os: macos-latest
             env: { name: hatch-test.py3.12-stable }
           - os: macos-latest
-            env: { name: hatch-test.py3.13-pre } # pre-release only needs one OS
+            env: { name: hatch-test.py3.14-pre } # pre-release only needs one OS
           - os: ubuntu-latest
             env: { name: hatch-test.py3.13-stable } # skipping because we run this as a coverage job
     name: ${{ matrix.env.label }} (${{ matrix.os }})

--- a/hatch.toml
+++ b/hatch.toml
@@ -15,8 +15,8 @@ scripts.download = "python ./.scripts/ci/download_data.py {args}"
 dependency-groups = ["test"]
 extra-dependencies = ["diff-cover"]
 matrix = [
-  { deps = ["stable"], python = ["3.11", "3.12", "3.13"] },
-  { deps = ["pre"], python = ["3.13"] },
+  { deps = ["stable"], python = ["3.11", "3.12", "3.13", "3.14"] },
+  { deps = ["pre"], python = ["3.14"] },
 ]
 overrides.matrix.deps.env-vars = [
   { key = "UV_PRERELEASE", value = "allow", if = ["pre"] },


### PR DESCRIPTION
## What

Add **Python 3.14** to the `hatch-test` matrix in `hatch.toml` (stable + the pre-release variant), and move the pre-release job from 3.13 → 3.14 (newest), updating the macOS exclude to match.

```toml
# hatch.toml [envs.hatch-test]
matrix = [
  { deps = ["stable"], python = ["3.11", "3.12", "3.13", "3.14"] },
  { deps = ["pre"], python = ["3.14"] },
]
```

## Why

Squidpy already *declares* 3.14 support (`requires-python = ">=3.11"`, classifiers through 3.14), but the test matrix was pinned to 3.11–3.13, so **3.14 was never actually exercised**.