### PR TITLE
Require Python >=3.12, test up to 3.14

### DIFF
--- a/.github/workflows/test-notebooks.yaml
+++ b/.github/workflows/test-notebooks.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Restore data cache
         id: data-cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Restore data cache
         id: data-cache
@@ -99,13 +99,11 @@ jobs:
         env: ${{ fromJSON(needs.get-environments.outputs.envs) }}
         exclude:
           - os: macos-latest
-            env: { name: hatch-test.py3.11-stable }
-          - os: macos-latest
             env: { name: hatch-test.py3.12-stable }
           - os: macos-latest
             env: { name: hatch-test.py3.14-pre } # pre-release only needs one OS
           - os: ubuntu-latest
-            env: { name: hatch-test.py3.13-stable } # skipping because we run this as a coverage job
+            env: { name: hatch-test.py3.14-stable } # skipping because we run this as a coverage job
     name: ${{ matrix.env.label }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ contains(matrix.env.name, 'pre') }}
@@ -165,7 +163,7 @@ jobs:
           path: ${{ github.workspace }}/tests/figures/*
 
   coverage:
-    name: Coverage (ubuntu-latest, hatch-test.py3.13-stable)
+    name: Coverage (ubuntu-latest, hatch-test.py3.14-stable)
     needs: [ensure-data-is-cached]
     runs-on: ubuntu-latest
     steps:
@@ -177,7 +175,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache-dependency-glob: pyproject.toml
 
       - name: Ensure figure directory exists
@@ -203,17 +201,17 @@ jobs:
           sudo Xvfb :42 -screen 0 1920x1080x24 -ac +extension GLX </dev/null &
 
       - name: create hatch environment
-        run: uvx hatch env create hatch-test.py3.13-stable
+        run: uvx hatch env create hatch-test.py3.14-stable
 
       - name: run coverage tests
         env:
           PLATFORM: ubuntu-latest
           DISPLAY: :42
         run: |
-          uvx hatch run hatch-test.py3.13-stable:cov-erase
-          uvx hatch run hatch-test.py3.13-stable:run-cov -v --color=yes
-          uvx hatch run hatch-test.py3.13-stable:cov-combine
-          uvx hatch run hatch-test.py3.13-stable:cov-report
+          uvx hatch run hatch-test.py3.14-stable:cov-erase
+          uvx hatch run hatch-test.py3.14-stable:run-cov -v --color=yes
+          uvx hatch run hatch-test.py3.14-stable:cov-combine
+          uvx hatch run hatch-test.py3.14-stable:cov-report
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Head over to the [documentation](https://squidpy.readthedocs.io/en/stable/) for 
 
 ## Installation
 
-We recommend running Squidpy on a recent Linux or macOS system with Python ≥3.11, but it also works on Windows via WSL.
+We recommend running Squidpy on a recent Linux or macOS system with Python ≥3.12, but it also works on Windows via WSL.
 
 Install from [PyPI](https://pypi.org/project/squidpy) with:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -63,8 +63,8 @@ This will list “Standalone” environments and a table of “Matrix” environ
 | Name       | Type    | Envs                     | Features | Dependencies                    | Scripts     |
 +------------+---------+--------------------------+----------+---------------------------------+-------------+
 | hatch-test | virtual | hatch-test.py3.10-stable | dev      | coverage-enable-subprocess==1.0 | cov-combine |
-|            |         | hatch-test.py3.13-stable | test     | coverage[toml]~=7.4             | cov-report  |
-|            |         | hatch-test.py3.13-pre    |          | pytest-mock~=3.12               | run         |
+|            |         | hatch-test.py3.14-stable | test     | coverage[toml]~=7.4             | cov-report  |
+|            |         | hatch-test.py3.14-pre    |          | pytest-mock~=3.12               | run         |
 |            |         |                          |          | pytest-randomly~=3.15           | run-cov     |
 |            |         |                          |          | pytest-rerunfailures~=14.0      |             |
 |            |         |                          |          | pytest-xdist[psutil]~=3.5       |             |
@@ -73,18 +73,18 @@ This will list “Standalone” environments and a table of “Matrix” environ
 ```
 
 From the `Envs` column, select the environment name you want to use for development.
-In this example, it would be `hatch-test.py3.13-stable`.
+In this example, it would be `hatch-test.py3.14-stable`.
 
 Next, create the environment with
 
 ```bash
-hatch env create hatch-test.py3.13-stable
+hatch env create hatch-test.py3.14-stable
 ```
 
 Then, obtain the path to the environment using
 
 ```bash
-hatch env find hatch-test.py3.13-stable
+hatch env find hatch-test.py3.14-stable
 ```
 
 In case you are using VScode, now open the command palette (Ctrl+Shift+P) and search for `Python: Select Interpreter`.

--- a/hatch.toml
+++ b/hatch.toml
@@ -15,7 +15,7 @@ scripts.download = "python ./.scripts/ci/download_data.py {args}"
 dependency-groups = ["test"]
 extra-dependencies = ["diff-cover"]
 matrix = [
-  { deps = ["stable"], python = ["3.11", "3.12", "3.13", "3.14"] },
+  { deps = ["stable"], python = ["3.12", "3.13", "3.14"] },
   { deps = ["pre"], python = ["3.14"] },
 ]
 overrides.matrix.deps.env-vars = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,15 @@ lint.ignore = [
   "E731",
   # allow I, O, l as variable names -> I is the identity matrix, i, j, k, l is reasonable indexing notation
   "E741",
+  # PEP 695 generics (`class C[T]` / `def f[T]`) -> deferred to a dedicated rewrite.
+  # `GraphMatrixT`/`CoordT` are a shared TypeVar pair: defined in `gr.neighbors`, used by a
+  # module-level `Callable` alias, imported by `gr._build`, and re-exported from the public
+  # `squidpy.gr` API. ruff cannot autofix the cross-module use (`SpatialNeighborsResult`, which
+  # imports the TypeVar) and its fix for the local use (`GraphBuilder`) leaves the still-required
+  # exported TypeVars in place, creating dual same-name definitions. Converting correctly means
+  # deciding whether to keep exporting `GraphMatrixT` -- a public-API change, not a version bump.
+  "UP046",
+  "UP047",
   ## Flake8 rules not supported by ruff:
   # RST201 Block quote ends without a blank line; unexpected unindent.
   # "RST201",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ maintainers = [
 authors = [
   { name = "scverse" },
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -31,7 +31,6 @@ classifiers = [
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
@@ -143,7 +142,7 @@ version.source = "vcs"
 [tool.pixi]
 workspace.channels = [ "conda-forge" ]
 workspace.platforms = [ "linux-64", "osx-arm64" ]
-dependencies.python = ">=3.11"
+dependencies.python = ">=3.12"
 pypi-dependencies.squidpy = { path = ".", editable = true }
 tasks.format = "ruff format ."
 tasks.kernel-install = 'python -m ipykernel install --user --name pixi-dev --display-name "squidpy (dev)"'
@@ -152,14 +151,14 @@ tasks.lint = "ruff check ."
 tasks.pre-commit = "pre-commit run"
 tasks.pre-commit-install = "pre-commit install"
 tasks.test = "pytest -v --color=yes --tb=short --durations=10"
-feature.py311.dependencies.python = "3.11.*"
-feature.py313.dependencies.python = "3.13.*"
-environments.default = { features = [ "py313" ], solve-group = "py313" }
-environments.dev-py311 = { features = [ "dev", "test", "py311" ], solve-group = "py311" }
-environments.dev-py313 = { features = [ "dev", "test", "py313" ], solve-group = "py313" }
-environments.docs-py311 = { features = [ "docs", "py311" ], solve-group = "py311" }
-environments.docs-py313 = { features = [ "docs", "py313" ], solve-group = "py313" }
-environments.test-py313 = { features = [ "test", "py313" ], solve-group = "py313" }
+feature.py312.dependencies.python = "3.12.*"
+feature.py314.dependencies.python = "3.14.*"
+environments.default = { features = [ "py314" ], solve-group = "py314" }
+environments.dev-py312 = { features = [ "dev", "test", "py312" ], solve-group = "py312" }
+environments.dev-py314 = { features = [ "dev", "test", "py314" ], solve-group = "py314" }
+environments.docs-py312 = { features = [ "docs", "py312" ], solve-group = "py312" }
+environments.docs-py314 = { features = [ "docs", "py314" ], solve-group = "py314" }
+environments.test-py314 = { features = [ "test", "py314" ], solve-group = "py314" }
 
 [tool.ruff]
 line-length = 120

--- a/src/squidpy/gr/_ligrec.py
+++ b/src/squidpy/gr/_ligrec.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from functools import partial
 from itertools import product
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -31,11 +31,11 @@ from squidpy.gr._utils import (
 
 __all__ = ["ligrec", "PermutationTest"]
 
-StrSeq: TypeAlias = Sequence[str]
-SeqTuple: TypeAlias = Sequence[tuple[str, str]]
-Interaction_t: TypeAlias = pd.DataFrame | Mapping[str, StrSeq] | StrSeq | tuple[StrSeq, StrSeq] | SeqTuple
+type StrSeq = Sequence[str]
+type SeqTuple = Sequence[tuple[str, str]]
+type Interaction_t = pd.DataFrame | Mapping[str, StrSeq] | StrSeq | tuple[StrSeq, StrSeq] | SeqTuple
 
-Cluster_t: TypeAlias = StrSeq | tuple[StrSeq, StrSeq] | SeqTuple
+type Cluster_t = StrSeq | tuple[StrSeq, StrSeq] | SeqTuple
 
 SOURCE = "source"
 TARGET = "target"

--- a/src/squidpy/im/_container.py
+++ b/src/squidpy/im/_container.py
@@ -7,7 +7,7 @@ from functools import partial
 from itertools import chain
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal
 
 import dask.array as da
 import matplotlib as mpl
@@ -46,11 +46,11 @@ from squidpy.im._coords import (
 from squidpy.im._feature_mixin import FeatureMixin
 from squidpy.im._io import _assert_dims_present, _infer_dimensions, _lazy_load_image
 
-FoI_t: TypeAlias = int | float
-Pathlike_t: TypeAlias = str | Path
-Arraylike_t: TypeAlias = NDArrayA | xr.DataArray
-InferDims_t: TypeAlias = Literal["default", "prefer_channels", "prefer_z"] | Sequence[str]
-Input_t: TypeAlias = Pathlike_t | Arraylike_t | Literal["ImageContainer"]
+type FoI_t = int | float
+type Pathlike_t = str | Path
+type Arraylike_t = NDArrayA | xr.DataArray
+type InferDims_t = Literal["default", "prefer_channels", "prefer_z"] | Sequence[str]
+type Input_t = Pathlike_t | Arraylike_t | Literal["ImageContainer"]
 _ERROR_NOTIMPLEMENTED_LIBID = f"It seems there are multiple `library_id` in `adata.uns[{Key.uns.spatial!r}]`.\n \
                                 Loading multiple images is not implemented (yet), please specify a `library_id`."
 

--- a/src/squidpy/im/_feature_mixin.py
+++ b/src/squidpy/im/_feature_mixin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
 import skimage.measure
@@ -15,8 +15,8 @@ from squidpy._utils import NDArrayA
 from squidpy._validators import assert_non_empty_sequence
 from squidpy.im._coords import _NULL_PADDING, CropCoords
 
-Feature_t: TypeAlias = dict[str, Any]
-Channel_t: TypeAlias = int | Sequence[int]
+type Feature_t = dict[str, Any]
+type Channel_t = int | Sequence[int]
 
 
 def _get_channels(xr_img: NDArrayA | xr.DataArray, channels: Channel_t | None) -> list[int]:

--- a/src/squidpy/pl/_color_utils.py
+++ b/src/squidpy/pl/_color_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any, TypeAlias
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,7 +15,7 @@ from scanpy import logging as logg
 from squidpy._compat import add_colors_for_categorical_sample_annotation
 from squidpy._constants._pkg_constants import Key
 
-Palette_t: TypeAlias = str | ListedColormap | None
+type Palette_t = str | ListedColormap | None
 
 
 def _maybe_set_colors(

--- a/src/squidpy/pl/_spatial_utils.py
+++ b/src/squidpy/pl/_spatial_utils.py
@@ -6,7 +6,7 @@ from copy import copy
 from functools import partial
 from numbers import Number
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import dask.array as da
 import numpy as np
@@ -44,15 +44,15 @@ from squidpy.im._coords import CropCoords
 from squidpy.pl._color_utils import _get_palette, _maybe_set_colors
 from squidpy.pl._utils import _assert_value_in_obs
 
-_AvailShapes: TypeAlias = Literal["circle", "square", "hex"]
-Palette_t: TypeAlias = str | ListedColormap | None
-_Normalize: TypeAlias = Normalize | Sequence[Normalize]
-_SeqStr: TypeAlias = str | Sequence[str]
-_SeqFloat: TypeAlias = float | Sequence[float]
-_SeqArray: TypeAlias = NDArrayA | Sequence[NDArrayA]
-_CoordTuple: TypeAlias = tuple[int, int, int, int]
-_FontWeight: TypeAlias = Literal["light", "normal", "medium", "semibold", "bold", "heavy", "black"]
-_FontSize: TypeAlias = Literal["xx-small", "x-small", "small", "medium", "large", "x-large", "xx-large"]
+type _AvailShapes = Literal["circle", "square", "hex"]
+type Palette_t = str | ListedColormap | None
+type _Normalize = Normalize | Sequence[Normalize]
+type _SeqStr = str | Sequence[str]
+type _SeqFloat = float | Sequence[float]
+type _SeqArray = NDArrayA | Sequence[NDArrayA]
+type _CoordTuple = tuple[int, int, int, int]
+type _FontWeight = Literal["light", "normal", "medium", "semibold", "bold", "heavy", "black"]
+type _FontSize = Literal["xx-small", "x-small", "small", "medium", "large", "x-large", "xx-large"]
 
 
 # named tuples

--- a/src/squidpy/read/_utils.py
+++ b/src/squidpy/read/_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import Any
 
 import numpy as np
 from anndata import AnnData
@@ -15,7 +15,7 @@ from squidpy._constants._pkg_constants import Key
 from squidpy._utils import NDArrayA
 
 # Type alias for path-like objects
-PathLike: TypeAlias = os.PathLike[str] | str
+type PathLike = os.PathLike[str] | str
 
 
 def _read_counts(


### PR DESCRIPTION
Bumps the minimum supported Python to **3.12** (drops 3.11) and moves the primary test target to **3.14**.

## Changes
- `pyproject.toml`: `requires-python` and pixi python `>=3.12`; drop the 3.11 classifier; replace `py311`/`py313` pixi envs with `py312`/`py314`.
- `hatch.toml`: stable matrix now `3.12, 3.13, 3.14`.
- CI: coverage job + notebook runner move `3.13 -> 3.14`; drop the now-stale 3.11 macOS exclude.
- Docs: contributing guide.

## PEP 695 (ruff target follow-on)
The bump raises ruff's inferred target to 3.12, activating UP040/UP046/UP047.
- **UP040 adopted**: the 22 `X: TypeAlias = ...` aliases become `type X = ...`. All are annotation-only (no `get_args`/`isinstance`/`cast`/runtime reads), so the lazy `TypeAliasType` is behaviour-preserving - verified the package imports and every alias resolves.
- **UP046/UP047 ignored**: `GraphMatrixT`/`CoordT` are a shared TypeVar pair - defined in `gr.neighbors`, used by a module-level `Callable` alias, imported by `gr._build`, and re-exported from the public `squidpy.gr` API. ruff cannot autofix the cross-module use (`SpatialNeighborsResult`, which imports the TypeVar) and its fix for the local use (`GraphBuilder`) leaves the still-required exported TypeVars in place, creating dual same-name definitions. A correct conversion has to decide whether to keep exporting `GraphMatrixT` - a public-API call, out of scope for a version bump.

## Notes
- 3.13 stays a supported, tested runtime (kept in matrix + classifiers); only the dedicated coverage/default target moved to 3.14.
- Breaking for anyone still on 3.11.