### PR TITLE
Drop GraphMatrixT export and make GraphPostprocessor a PEP 695 type alias

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -23,7 +23,6 @@ import squidpy as sq
     gr.spatial_neighbors_radius
     gr.spatial_neighbors_delaunay
     gr.spatial_neighbors_grid
-    gr.GraphMatrixT
     gr.SpatialNeighborsResult
     gr.mask_graph
     gr.nhood_enrichment
@@ -129,7 +128,6 @@ See the {doc}`extensibility guide </extensibility>` for how to implement a custo
 
     gr.neighbors.GraphBuilder
     gr.neighbors.GraphBuilderCSR
-    gr.neighbors.GraphMatrixT
     gr.neighbors.GraphPostprocessor
     gr.neighbors.DistanceIntervalPostprocessor
     gr.neighbors.PercentilePostprocessor

--- a/src/squidpy/gr/__init__.py
+++ b/src/squidpy/gr/__init__.py
@@ -24,10 +24,8 @@ from squidpy.gr._niche import calculate_niche
 from squidpy.gr._ppatterns import co_occurrence, spatial_autocorr
 from squidpy.gr._ripley import ripley
 from squidpy.gr._sepal import sepal
-from squidpy.gr.neighbors import GraphMatrixT
 
 __all__ = [
-    "GraphMatrixT",
     "SpatialNeighborsResult",
     "NhoodEnrichmentResult",
     "neighbors",

--- a/src/squidpy/gr/neighbors.py
+++ b/src/squidpy/gr/neighbors.py
@@ -9,7 +9,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
 import numpy as np
 from fast_array_utils import stats as fau_stats
@@ -31,7 +31,6 @@ from squidpy._utils import NDArrayA
 from squidpy._validators import assert_positive
 
 __all__ = [
-    "GraphMatrixT",
     "GraphBuilder",
     "GraphBuilderCSR",
     "GraphPostprocessor",
@@ -45,10 +44,9 @@ __all__ = [
 ]
 
 
-# Kept module-level (not folded into GraphBuilder's params): types the public
-# `GraphPostprocessor` alias and is itself a public `squidpy.gr` export.
-GraphMatrixT = TypeVar("GraphMatrixT")
-GraphPostprocessor = Callable[[GraphMatrixT, GraphMatrixT], tuple[GraphMatrixT, GraphMatrixT]]
+# Public PEP 695 type alias for graph postprocessors. The type parameter is
+# scoped to the alias itself, so no module-level `TypeVar` is needed.
+type GraphPostprocessor[GraphMatrixT] = Callable[[GraphMatrixT, GraphMatrixT], tuple[GraphMatrixT, GraphMatrixT]]
 
 
 class GraphBuilder[CoordT, GraphMatrixT](ABC):


### PR DESCRIPTION
Follow-up to #1222. That PR deliberately left out two breaking changes (see its "Deliberately not done" section); now that the graph-builder API is still experimental, this applies both.

## Changes
- **Drop `GraphMatrixT` from the public API.** Removed from `__all__` in `squidpy.gr` and `squidpy.gr.neighbors`, plus the two autosummary entries in `docs/api.md`. It was only exported to back the `GraphPostprocessor` alias.
- **Convert `GraphPostprocessor` to a PEP 695 `type` alias** whose type parameter is scoped to the alias itself. This removes the now-unused module-level `GraphMatrixT = TypeVar(...)` and the `TypeVar` import.

## Breaking changes
- `from squidpy.gr import GraphMatrixT` (and `from squidpy.gr.neighbors import GraphMatrixT`) no longer works — the name is gone.
- `GraphPostprocessor`'s runtime type changes from a plain `typing` `Callable` form to `TypeAliasType`. Type-level usage (`GraphPostprocessor[csr_matrix]`, annotations) is unchanged.

The `GraphBuilder[CoordT, GraphMatrixT]` class param and `SpatialNeighborsResult[GraphMatrixT]` are independent PEP 695 params and are unaffected.

## Verification
- `ruff check src/squidpy/gr/` clean.
- Runtime asserts: `type(GraphPostprocessor).__name__ == "TypeAliasType"`, `GraphPostprocessor[csr_matrix]` still subscriptable, `GraphMatrixT` absent from both `__all__`s and no longer an attribute of `squidpy.gr.neighbors`.
- `tests/graph/test_spatial_neighbors.py`: 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)