### PR TITLE
unify thread and process helpers

### DIFF
--- a/src/squidpy/_utils.py
+++ b/src/squidpy/_utils.py
@@ -306,16 +306,47 @@ def thread_map(
     return _run(None)
 
 
-def _get_n_cores(n_cores: int | None) -> int:
-    """
-    Make number of cores a positive integer.
+def get_n_threads(n_threads: int | None) -> int:
+    """Resolve a numba thread count, defaulting to numba's own default.
 
-    This is useful for especially logging.
+    Use for ``@njit(parallel=True)`` kernels whose parallelism is a single numba call.
+
+    Parameters
+    ----------
+    n_threads
+        Requested number of threads. ``None`` uses numba's default
+        (:attr:`numba.config.NUMBA_NUM_THREADS`, usually all cores); positive values are
+        clamped to ``[1, NUMBA_NUM_THREADS]``; negative values count down from the maximum
+        (``-1`` is all-but-one).
+
+    Returns
+    -------
+    int
+        Positive thread count in ``[1, NUMBA_NUM_THREADS]``.
+    """
+    max_threads = numba.config.NUMBA_NUM_THREADS
+    if n_threads is None:
+        return max_threads
+    if n_threads == 0:
+        raise ValueError("Number of threads cannot be `0`.")
+    if n_threads < 0:
+        return max(1, max_threads + 1 + n_threads)
+
+    return min(n_threads, max_threads)
+
+
+def get_n_processes(n_cores: int | None) -> int:
+    """Make number of processes a positive integer, mainly for :func:`parallelize` and logging.
+
+    .. deprecated::
+        Kept for the process-based :func:`parallelize`/:func:`thread_map` helpers; slated for
+        removal once those call sites migrate to numba threading (see :func:`get_n_threads`).
 
     Parameters
     ----------
     n_cores
-        Number of cores to use.
+        Number of cores to use. ``None`` is serial (``1``); negative values count down from
+        the cpu count (``-1`` is all-but-one).
 
     Returns
     -------

--- a/src/squidpy/experimental/im/_tiling.py
+++ b/src/squidpy/experimental/im/_tiling.py
@@ -22,7 +22,7 @@ from skimage.measure import regionprops
 from spatialdata._logging import logger as logg
 from tqdm.auto import tqdm
 
-from squidpy._utils import _get_n_cores, thread_map
+from squidpy._utils import get_n_processes, thread_map
 
 
 def yx_size(da: xr.DataArray) -> tuple[int, int]:
@@ -452,7 +452,7 @@ def _run_tiled(
     """Run ``process_fn(spec, *scatter)`` over tile ``specs``; return results in spec order.
 
     Engine selection: an active ``distributed.Client`` wins; else ``n_jobs`` (repo
-    ``_get_n_cores`` convention, ``1``/``0``/``None`` serial) picks workers and
+    ``get_n_processes`` convention, ``1``/``0``/``None`` serial) picks workers and
     ``kind`` picks the scheduler -- ``"threads"`` for GIL-releasing work (numba
     ``nogil``), ``"processes"`` for GIL-bound work (a ``LocalCluster``, since the
     local multiprocessing scheduler does not fork). ``scatter`` holds large objects
@@ -470,7 +470,7 @@ def _run_tiled(
             logg.warning("`n_jobs` is ignored when an active dask.distributed Client is in scope.")
         return _run_on_client(get_client(), specs, process_fn, scatter, desc)
 
-    workers = 1 if n_jobs in (None, 0) else _get_n_cores(n_jobs)
+    workers = 1 if n_jobs in (None, 0) else get_n_processes(n_jobs)
     # Never spin up more workers than tiles: idle workers only add process-startup
     # and scatter cost. (n <= 1 also routes to the serial path below.)
     workers = min(workers, n)

--- a/src/squidpy/gr/_ligrec.py
+++ b/src/squidpy/gr/_ligrec.py
@@ -24,7 +24,7 @@ from squidpy._utils import (
     NDArrayA,
     Signal,
     SigQueue,
-    _get_n_cores,
+    get_n_processes,
     parallelize,
     spawn_generators,
 )
@@ -418,7 +418,7 @@ class PermutationTestABC(ABC):
         # much faster than applymap (tested on 1M interactions)
         interactions_ = np.vectorize(lambda g: gene_mapper[g])(interactions.values)
 
-        n_jobs = _get_n_cores(kwargs.pop("n_jobs", None))
+        n_jobs = get_n_processes(kwargs.pop("n_jobs", None))
         start = logg.info(
             f"Running `{n_perms}` permutations on `{len(interactions)}` interactions "
             f"and `{len(clusters)}` cluster combinations using `{n_jobs}` core(s)"

--- a/src/squidpy/gr/_nhood.py
+++ b/src/squidpy/gr/_nhood.py
@@ -24,7 +24,7 @@ from squidpy._utils import (
     NDArrayA,
     Signal,
     SigQueue,
-    _get_n_cores,
+    get_n_processes,
     parallelize,
     spawn_generators,
 )
@@ -207,7 +207,7 @@ def nhood_enrichment(
     _test = _create_function(n_cls, parallel=numba_parallel)
     count = _test(indices, indptr, int_clust)
 
-    n_jobs = _get_n_cores(n_jobs)
+    n_jobs = get_n_processes(n_jobs)
     start = logg.info(f"Calculating neighborhood enrichment using `{n_jobs}` core(s)")
     generators = spawn_generators(seed, n_perms)
 
@@ -312,7 +312,7 @@ def centrality_scores(
         else:
             raise NotImplementedError(f"Centrality `{c}` is not yet implemented.")
 
-    n_jobs = _get_n_cores(n_jobs)
+    n_jobs = get_n_processes(n_jobs)
     start = logg.info(f"Calculating centralities `{centralities}` using `{n_jobs}` core(s)")
 
     res_list = []

--- a/src/squidpy/gr/_ppatterns.py
+++ b/src/squidpy/gr/_ppatterns.py
@@ -26,8 +26,8 @@ from squidpy._utils import (
     NDArrayA,
     Signal,
     SigQueue,
-    _get_n_cores,
     deprecated_params,
+    get_n_processes,
     parallelize,
     spawn_generators,
 )
@@ -215,7 +215,7 @@ def spatial_autocorr(
 
     score = params["func"](g, vals)  # type: ignore
 
-    n_jobs = _get_n_cores(n_jobs)
+    n_jobs = get_n_processes(n_jobs)
     start = logg.info(f"Calculating {mode}'s statistic for `{n_perms}` permutations using `{n_jobs}` core(s)")
     if n_perms is not None:
         assert_positive(n_perms, name="n_perms")

--- a/src/squidpy/gr/_sepal.py
+++ b/src/squidpy/gr/_sepal.py
@@ -14,7 +14,7 @@ from spatialdata import SpatialData
 
 from squidpy._constants._pkg_constants import Key
 from squidpy._docs import d, inject_docs
-from squidpy._utils import NDArrayA, _get_n_cores, deprecated_params, thread_map
+from squidpy._utils import NDArrayA, deprecated_params, get_n_processes, thread_map
 from squidpy._validators import assert_non_empty_sequence
 from squidpy.gr._utils import (
     _assert_connectivity_key,
@@ -111,7 +111,7 @@ def sepal(
             genes = genes[adata.var["highly_variable"].values]
     genes = assert_non_empty_sequence(genes, name="genes")
 
-    n_jobs = _get_n_cores(n_jobs)
+    n_jobs = get_n_processes(n_jobs)
 
     g = adata.obsp[connectivity_key]
     if not isspmatrix_csr(g):

--- a/src/squidpy/im/_feature.py
+++ b/src/squidpy/im/_feature.py
@@ -10,7 +10,7 @@ from scanpy import logging as logg
 
 from squidpy._constants._constants import ImageFeature
 from squidpy._docs import d, inject_docs
-from squidpy._utils import Signal, SigQueue, _get_n_cores, parallelize
+from squidpy._utils import Signal, SigQueue, get_n_processes, parallelize
 from squidpy.gr._utils import _save_data
 from squidpy.im._container import ImageContainer
 
@@ -84,7 +84,7 @@ def calculate_image_features(
         features = [features]
     features = sorted({ImageFeature(f).s for f in features})
 
-    n_jobs = _get_n_cores(n_jobs)
+    n_jobs = get_n_processes(n_jobs)
     start = logg.info(f"Calculating features `{list(features)}` using `{n_jobs}` core(s)")
 
     res = parallelize(


### PR DESCRIPTION
This pull request refactors how the number of parallel workers is determined throughout the codebase. It deprecates the old `_get_n_cores` utility in favor of a new `get_n_processes` function for process-based parallelization and introduces `get_n_threads` for numba-based threading. All relevant imports and function calls are updated to use the new functions, ensuring more consistent and descriptive handling of parallelism.

**Parallelization utilities refactor:**

* Added `get_n_threads` to `src/squidpy/_utils.py` for resolving numba thread counts, and replaced `_get_n_cores` with `get_n_processes`, which is now used for process-based parallelization and is marked as deprecated in favor of numba threading where appropriate.
* Updated all imports and usages of `_get_n_cores` to `get_n_processes` in the following modules: `src/squidpy/experimental/im/_tiling.py`, `src/squidpy/gr/_ligrec.py`, `src/squidpy/gr/_nhood.py`, `src/squidpy/gr/_ppatterns.py`, `src/squidpy/gr/_sepal.py`, and `src/squidpy/im/_feature.py`. [[1]](diffhunk://#diff-54826d95fe3ddfd7f0e261a7244bd955717b360c9d066307ba7ab49387fda9a5L25-R25) [[2]](diffhunk://#diff-f8ee1194403b12d9f322b38697977a0c6403eeb9f92aa402572e3be73d112fe7L27-R27) [[3]](diffhunk://#diff-b0f880b8a8accb2572d8e7c94512c48a8ebc1d2b47c43542eefc3762525f4d31L27-R27) [[4]](diffhunk://#diff-bf9a241973b44a1f9a215d07f233adf22089da131b7569a6dee3d5b6616a8d88L29-R30) [[5]](diffhunk://#diff-62cae86a57d912d2c557f624c90a1c44b0c387fe2870e2813ea56a9c83ef8832L17-R17) [[6]](diffhunk://#diff-cd382ef5e29e7c0c77d6a34031b03250306ab5608a0ff3f72bc977c882bfb289L13-R13)
* Replaced all internal calls to `_get_n_cores` with `get_n_processes` for determining the number of worker processes or threads in parallel computations. [[1]](diffhunk://#diff-54826d95fe3ddfd7f0e261a7244bd955717b360c9d066307ba7ab49387fda9a5L473-R473) [[2]](diffhunk://#diff-f8ee1194403b12d9f322b38697977a0c6403eeb9f92aa402572e3be73d112fe7L421-R421) [[3]](diffhunk://#diff-b0f880b8a8accb2572d8e7c94512c48a8ebc1d2b47c43542eefc3762525f4d31L210-R210) [[4]](diffhunk://#diff-b0f880b8a8accb2572d8e7c94512c48a8ebc1d2b47c43542eefc3762525f4d31L315-R315) [[5]](diffhunk://#diff-bf9a241973b44a1f9a215d07f233adf22089da131b7569a6dee3d5b6616a8d88L218-R218) [[6]](diffhunk://#diff-62cae86a57d912d2c557f624c90a1c44b0c387fe2870e2813ea56a9c83ef8832L114-R114) [[7]](diffhunk://#diff-cd382ef5e29e7c0c77d6a34031b03250306ab5608a0ff3f72bc977c882bfb289L87-R87)
* Updated documentation and comments to reference the new `get_n_processes` convention and clarify its intended usage and deprecation plan.

These changes standardize parallelization configuration, improve code clarity, and prepare the codebase for future migration to numba threading.