### PR TITLE
fix: avoid obs_vector FutureWarning in spatial_scatter

### DIFF
--- a/src/squidpy/_compat.py
+++ b/src/squidpy/_compat.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 from importlib.metadata import version
+from typing import TYPE_CHECKING
 
 from packaging.version import Version
+from scanpy.get import obs_df
+
+if TYPE_CHECKING:
+    import numpy as np
+    from anndata import AnnData
 
 __all__ = [
     # scanpy
@@ -17,6 +23,7 @@ __all__ = [
     "ArrayView",
     "SparseCSCView",
     "SparseCSRView",
+    "get_vector",
 ]
 
 # Scanpy 1.13 moved the pre-v2 plotting internals under ``scanpy.plotting.legacy``.
@@ -68,6 +75,21 @@ except ImportError:
 
     def vector_friendly() -> bool:
         return _sc_settings._vector_friendly
+
+
+def get_vector(adata: AnnData, key: str, *, layer: str | None = None, use_raw: bool | None = None) -> np.ndarray:
+    """Return a 1-D vector of values for ``key`` from ``.obs`` or ``.var_names``.
+
+    Drop-in replacement for ``AnnData.obs_vector`` that avoids the ``FutureWarning``
+    emitted by anndata >= 0.13 (see https://github.com/scverse/squidpy/issues/1261).
+    Delegates to :func:`scanpy.get.obs_df`, whose contract already covers ``.obs``
+    columns and ``.var_names`` genes (honoring ``layer`` / ``use_raw`` and preserving
+    ``Categorical`` dtype), mirroring the ``use_raw``-then-``layer`` precedence of the
+    original ``obs_vector`` calls.
+    """
+    if use_raw and key not in adata.obs:
+        return obs_df(adata, keys=[key], use_raw=True)[key].values
+    return obs_df(adata, keys=[key], layer=layer)[key].values
 
 
 CAN_USE_SPARSE_ARRAY = Version(version("anndata")) >= Version("0.11.0rc1")

--- a/src/squidpy/pl/_spatial_utils.py
+++ b/src/squidpy/pl/_spatial_utils.py
@@ -34,7 +34,7 @@ from skimage.morphology import erosion, square
 from skimage.segmentation import find_boundaries
 from skimage.util import map_array
 
-from squidpy._compat import add_categorical_legend, default_frameon, vector_friendly
+from squidpy._compat import add_categorical_legend, default_frameon, get_vector, vector_friendly
 from squidpy._constants._constants import ScatterShape
 from squidpy._constants._pkg_constants import Key
 from squidpy._utils import NDArrayA
@@ -461,10 +461,7 @@ def _set_color_source_vec(
 
     if alt_var is not None and value_to_plot not in adata.obs and value_to_plot not in adata.var_names:
         value_to_plot = adata.var_names[adata.var[alt_var] == value_to_plot][0]
-    if use_raw and value_to_plot not in adata.obs:
-        color_source_vector = adata.raw.obs_vector(value_to_plot)
-    else:
-        color_source_vector = adata.obs_vector(value_to_plot, layer=layer)
+    color_source_vector = get_vector(adata, value_to_plot, layer=layer, use_raw=use_raw)
 
     if not isinstance(color_source_vector.dtype, CategoricalDtype):
         return None, color_source_vector, False


### PR DESCRIPTION
anndata >=0.13 deprecates `AnnData.obs_vector`, which `_set_color_source_vec` calls on every `spatial_scatter` coloring by an obs column or gene, surfacing a `FutureWarning` to users.

Route both lookups through a `get_vector` shim that delegates to `scanpy.get.obs_df` (already a dependency), preserving the original `use_raw`/`layer` precedence and `Categorical` dtype.

Closes #1261