### PR TITLE
fix: reap leaked dask workers in process-based featurization

### DIFF
--- a/src/squidpy/experimental/im/_tiling.py
+++ b/src/squidpy/experimental/im/_tiling.py
@@ -12,6 +12,7 @@ never materialize the full image or label array.
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -481,13 +482,28 @@ def _run_tiled(
     # LocalCluster. (dask's ProgressBar cannot observe a distributed cluster; the
     # tqdm bar in _run_on_client drives progress there.)
     if kind == "processes" and workers > 1 and n > 1:
+        import psutil  # ships with distributed
         from dask.distributed import Client, LocalCluster
 
-        with (
-            LocalCluster(n_workers=workers, threads_per_worker=1, processes=True, dashboard_address=None) as cluster,
-            Client(cluster) as client,
-        ):
-            return _run_on_client(client, specs, process_fn, scatter, desc)
+        # Under Python 3.14, distributed can leave spawned worker/nanny processes alive
+        # after teardown. An orphan that inherited this process's stdout/stderr keeps the
+        # pipe open, so a consumer waiting for EOF (e.g. CI log capture) hangs forever.
+        # Track the cluster's own children and reap any survivor as a backstop. See #1267.
+        self_proc = psutil.Process()
+        before = {c.pid for c in self_proc.children(recursive=True)}
+        cluster = LocalCluster(n_workers=workers, threads_per_worker=1, processes=True, dashboard_address=None)
+        try:
+            with Client(cluster) as client:
+                return _run_on_client(client, specs, process_fn, scatter, desc)
+        finally:
+            cluster.close()
+            # Reap any process the cluster spawned (workers, nannies, resource tracker)
+            # that outlived close(); leave the host app's pre-existing children untouched.
+            victims = [c for c in self_proc.children(recursive=True) if c.pid not in before]
+            for child in victims:
+                with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+                    child.kill()
+            psutil.wait_procs(victims, timeout=10)
 
     # Local path: reuse the shared threaded map (serial for 1 worker / 1 tile,
     # threads otherwise). Bind scatter into the closure rather than passing the

--- a/src/squidpy/experimental/im/_tiling.py
+++ b/src/squidpy/experimental/im/_tiling.py
@@ -13,7 +13,7 @@ never materialize the full image or label array.
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -415,6 +415,34 @@ def _has_distributed_client() -> bool:
     return True
 
 
+@contextlib.contextmanager
+def _local_cluster(n_workers: int) -> Iterator[Any]:
+    """A process-based ``LocalCluster`` whose spawned processes are reaped on exit.
+
+    Under Python 3.14, distributed can leave spawned worker/nanny processes alive
+    after teardown. An orphan that inherited this process's stdout/stderr keeps the
+    pipe open, so a consumer waiting for EOF (e.g. CI log capture) hangs forever.
+    Track the cluster's own children and reap any survivor as a backstop. See #1267.
+    """
+    import psutil  # ships with distributed
+    from dask.distributed import LocalCluster
+
+    self_proc = psutil.Process()
+    before = {c.pid for c in self_proc.children(recursive=True)}
+    cluster = LocalCluster(n_workers=n_workers, threads_per_worker=1, processes=True, dashboard_address=None)
+    try:
+        yield cluster
+    finally:
+        cluster.close()
+        # Reap any process the cluster spawned (workers, nannies, resource tracker)
+        # that outlived close(); leave the host app's pre-existing children untouched.
+        victims = [c for c in self_proc.children(recursive=True) if c.pid not in before]
+        for child in victims:
+            with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+                child.kill()
+        psutil.wait_procs(victims, timeout=10)
+
+
 def _run_on_client(
     client: Any,
     specs: Sequence[Any],
@@ -482,28 +510,10 @@ def _run_tiled(
     # LocalCluster. (dask's ProgressBar cannot observe a distributed cluster; the
     # tqdm bar in _run_on_client drives progress there.)
     if kind == "processes" and workers > 1 and n > 1:
-        import psutil  # ships with distributed
-        from dask.distributed import Client, LocalCluster
+        from dask.distributed import Client
 
-        # Under Python 3.14, distributed can leave spawned worker/nanny processes alive
-        # after teardown. An orphan that inherited this process's stdout/stderr keeps the
-        # pipe open, so a consumer waiting for EOF (e.g. CI log capture) hangs forever.
-        # Track the cluster's own children and reap any survivor as a backstop. See #1267.
-        self_proc = psutil.Process()
-        before = {c.pid for c in self_proc.children(recursive=True)}
-        cluster = LocalCluster(n_workers=workers, threads_per_worker=1, processes=True, dashboard_address=None)
-        try:
-            with Client(cluster) as client:
-                return _run_on_client(client, specs, process_fn, scatter, desc)
-        finally:
-            cluster.close()
-            # Reap any process the cluster spawned (workers, nannies, resource tracker)
-            # that outlived close(); leave the host app's pre-existing children untouched.
-            victims = [c for c in self_proc.children(recursive=True) if c.pid not in before]
-            for child in victims:
-                with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):
-                    child.kill()
-            psutil.wait_procs(victims, timeout=10)
+        with _local_cluster(workers) as cluster, Client(cluster) as client:
+            return _run_on_client(client, specs, process_fn, scatter, desc)
 
     # Local path: reuse the shared threaded map (serial for 1 worker / 1 tile,
     # threads otherwise). Bind scatter into the closure rather than passing the

--- a/tests/experimental/test_calculate_image_features.py
+++ b/tests/experimental/test_calculate_image_features.py
@@ -1153,8 +1153,10 @@ class TestParallelEngine:
         Exercises the Client-first dispatch, scatter of a zarr-backed dask graph,
         and cp_measure running in worker processes (picklability of the config).
         """
-        from dask.distributed import Client, LocalCluster
+        from dask.distributed import Client
         from spatialdata import read_zarr
+
+        from squidpy.experimental.im._tiling import _local_cluster
 
         sdata_synthetic.write(tmp_path / "data.zarr")
         sdata = read_zarr(tmp_path / "data.zarr")  # zarr/dask-backed
@@ -1168,9 +1170,8 @@ class TestParallelEngine:
         # Serial baseline must be computed with no Client in scope.
         serial = _sorted_frame(sq.experimental.im.calculate_image_features(sdata, n_jobs=1, **kw))
 
-        with LocalCluster(n_workers=2, threads_per_worker=1, processes=True, dashboard_address=None) as cluster:
-            with Client(cluster):  # Client-first dispatch picks this up
-                parallel = _sorted_frame(sq.experimental.im.calculate_image_features(sdata, **kw))
+        with _local_cluster(2) as cluster, Client(cluster):  # Client-first dispatch picks this up
+            parallel = _sorted_frame(sq.experimental.im.calculate_image_features(sdata, **kw))
 
         pd.testing.assert_frame_equal(serial, parallel[serial.columns], rtol=1e-5, atol=1e-6)
 


### PR DESCRIPTION
Fixes #1267.

`_run_tiled(..., kind="processes")` runs work on a `LocalCluster(processes=True)`. Under Python 3.14 the cluster teardown can leave worker/nanny processes alive; an orphan that inherited stdout/stderr keeps the pipe open, so a consumer waiting for EOF (the CI coverage step) hangs indefinitely.

Fix: record the cluster's own child PIDs and reap any that outlive `close()`, leaving a host app's pre-existing children untouched. `psutil` is already a `distributed` dependency.
